### PR TITLE
Remove redundant status code

### DIFF
--- a/src/server_kemal.cr
+++ b/src/server_kemal.cr
@@ -1,17 +1,14 @@
 require "kemal"
 
 get "/" do |env|
-  env.response.status_code = 200
   nil
 end
 
 get "/user/:id" do |env|
-  env.response.status_code = 200
   env.params.url["id"]
 end
 
 post "/user" do |env|
-  env.response.status_code = 200
   nil
 end
 


### PR DESCRIPTION
Kemal already returns `200` by default so no need to set