### PR TITLE
Turn off logging

### DIFF
--- a/src/server_kemal.cr
+++ b/src/server_kemal.cr
@@ -1,5 +1,7 @@
 require "kemal"
 
+logging false
+
 get "/" do |env|
   env.response.status_code = 200
   nil


### PR DESCRIPTION
`route.cr` don't have logging and it's unfair to compare it Kemal which has logging on by default. This PR turns off Kemal's logging thus leads to more fair comparison. Also removed redundant status code