### PR TITLE
Turn off logging and remove redundant code

### DIFF
--- a/src/server_kemal.cr
+++ b/src/server_kemal.cr
@@ -1,17 +1,16 @@
 require "kemal"
 
+logging false
+
 get "/" do |env|
-  env.response.status_code = 200
   nil
 end
 
 get "/user/:id" do |env|
-  env.response.status_code = 200
   env.params.url["id"]
 end
 
 post "/user" do |env|
-  env.response.status_code = 200
   nil
 end
 


### PR DESCRIPTION
route.cr don't have logging and it's unfair to compare it Kemal which has logging on by default. This PR turns off Kemal's logging thus leads to more fair comparison. Also removed redundant status code