### PR TITLE
Add release to shard build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,12 @@ crystal: kemal route_cr
 
 # Kemal
 kemal: crystal/kemal/src/server.cr
-	cd crystal/kemal; shards build
+	cd crystal/kemal; shards build --release
 	ln -s -f ../crystal/kemal/bin/server_crystal_kemal bin/.
 
 # route.cr
 route_cr: crystal/route.cr/src/server.cr
-	cd crystal/route.cr; shards build
+	cd crystal/route.cr; shards build --release
 	ln -s -f ../crystal/route.cr/bin/server_crystal_route_cr bin/.
 
 # --- Go ---


### PR DESCRIPTION
Add `--release` to shards build like Rust/Cargo

shards allow to append custom options to build command

https://github.com/crystal-lang/shards/blob/master/src/commands/build.cr#L33