### PR TITLE
disable etag generation in express

### DIFF
--- a/node/express/app.js
+++ b/node/express/app.js
@@ -1,5 +1,6 @@
 var express = require('express')
 var app = express()
+app.set('etag', false);
 
 app.get('/', function (req, res) {
   res.send('')


### PR DESCRIPTION
the default hashing of the response and adding etag headers seems a bit too much.