### PR TITLE
Fix benchmarker killing self...

### DIFF
--- a/benchmarker/src/benchmarker.cr
+++ b/benchmarker/src/benchmarker.cr
@@ -74,7 +74,8 @@ class ExecServer
       Process.run("bash #{path} stop", shell: true)
     end
     # kill the server_lang_framework @process AND it's children
-    Process.run("pkill -9 -g $(ps -o pgid= #{@process.pid} | grep -o [0-9]*)", shell: true)
+    Process.run("pkill -9 -p #{@process.pid}", shell: true)
+    Process.run("kill -9 #{@process.pid}", shell: true)
   end
 end
 


### PR DESCRIPTION
As of a few PR's ago it seems the benchmarker keeps killing itself at the end of every test before it prints anything:
```shell
╭─overminddl1@snip ~/tmp/which_is_the_fastest  ‹asptest›
╰─➤  ./bin/benchmarker csharp
Language (Runtime)        Framework (Middleware)          Max [sec]       Min [sec]       Ave [sec]
------------------------- ------------------------- --------------- --------------- ---------------
[1]    29091 killed     ./bin/benchmarker csharp
```
And that is because they are `pkill -g`'ing the entire process group after getting the process group leader of the client process, which isthe benchmarker as it started the spawning of everything...

Should be killing the process children of just the process, this fixes that by killing the process children then the process itself, it works on the few I've tried it on so far without things staying running, but it will not work if anything double-forks (the prior method would not have worked on them either) but I'm not seeing anything doing that.