### PR TITLE
Use struct instead of class

### DIFF
--- a/crystal/router.cr/src/server.cr
+++ b/crystal/router.cr/src/server.cr
@@ -1,6 +1,6 @@
 require "router"
 
-class Server
+struct Server
 
   @route_handler = RouteHandler.new
 


### PR DESCRIPTION
According to Crystal docs:

> A struct can also includes modules and can be generic, just like a class.
> 
> A struct is mostly used for performance reasons to avoid lots of small memory allocations when passing small copies might be more efficient.
> 
> So how do you choose between a struct and a class? The rule of thumb is that if no instance variable is ever reassigned, i.e. your type is immutable, you could use a struct, otherwise use a class.

https://crystal-lang.org/docs/syntax_and_semantics/structs.html