### PR TITLE
Enable iris, while building with make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ amber:
 
 
 # --- Go ---
-go: echo gorilla-mux fasthttprouter gin
+go: echo gorilla-mux fasthttprouter gin iris
 
 # Echo
 echo:


### PR DESCRIPTION
Hi, 

`Iris`, **go**, was missing from `Makefile`