### PR TITLE
Fix threads -> Dynamic calculation was wrong

### DIFF
--- a/tools/src/benchmarker.cr
+++ b/tools/src/benchmarker.cr
@@ -130,7 +130,7 @@ end
 # requests : numbers of request per thread
 def client(threads, requests)
   s = Time.now
-  `#{CLIENT} #{threads} -r #{requests}`
+  `#{CLIENT} -t #{threads} -r #{requests}`
   e = Time.now
   (e - s).to_f
 end


### PR DESCRIPTION
Hi,

In `PR` #111, I removed given thread number given to client.

`16` **threads** was created instead of  `core + 1`.

Regards,