### PR TITLE
Use the last (stable) version for each dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,17 +186,17 @@ python: sanic japronto flask django
 
 # Sanic
 sanic:
-	cd python/sanic; pip3 install -r requirements.txt -U; chmod +x server_python_sanic.py
+	cd python/sanic; pip3 install -r requirements.txt -U --user; chmod +x server_python_sanic.py
 	ln -s -f ../python/sanic/server_python_sanic.py bin/server_python_sanic
 
 # Japronto
 japronto:
-	cd python/japronto; pip3 install -r requirements.txt -U; chmod +x server_python_japronto.py
+	cd python/japronto; pip3 install -r requirements.txt -U --user; chmod +x server_python_japronto.py
 	ln -s -f ../python/japronto/server_python_japronto.py bin/server_python_japronto
 
 # Flask
 flask:
-	cd python/flask; pip3 install -r requirements.txt -U; chmod +x server_python_flask.py
+	cd python/flask; pip3 install -r requirements.txt -U --user; chmod +x server_python_flask.py
 	ln -s -f ../python/flask/server_python_flask.py bin/server_python_flask
 
 # Django

--- a/Makefile
+++ b/Makefile
@@ -186,22 +186,22 @@ python: sanic japronto flask django
 
 # Sanic
 sanic:
-	cd python/sanic; pip3 install -r requirements.txt; chmod +x server_python_sanic.py
+	cd python/sanic; pip3 install -r requirements.txt -U; chmod +x server_python_sanic.py
 	ln -s -f ../python/sanic/server_python_sanic.py bin/server_python_sanic
 
 # Japronto
 japronto:
-	cd python/japronto; pip3 install -r requirements.txt; chmod +x server_python_japronto.py
+	cd python/japronto; pip3 install -r requirements.txt -U; chmod +x server_python_japronto.py
 	ln -s -f ../python/japronto/server_python_japronto.py bin/server_python_japronto
 
 # Flask
 flask:
-	cd python/flask; pip3 install -r requirements.txt; chmod +x server_python_flask.py
+	cd python/flask; pip3 install -r requirements.txt -U; chmod +x server_python_flask.py
 	ln -s -f ../python/flask/server_python_flask.py bin/server_python_flask
 
 # Django
 django:
-	cd python/django; pip3 install -r requirements.txt --user
+	cd python/django; pip3 install -r requirements.txt -U --user
 	ln -s -f ../python/django/server_python_django bin/server_python_django
 
 

--- a/python/django/server_python_django
+++ b/python/django/server_python_django
@@ -1,1 +1,1 @@
-cd python/django;gunicorn app.wsgi --bind 127.0.0.1:3000
+cd python/django;python3 `which gunicorn` app.wsgi --bind 127.0.0.1:3000

--- a/python/django/settings.py
+++ b/python/django/settings.py
@@ -10,7 +10,7 @@ SECRET_KEY = '3f51&0k++@_2u24_v@f)_-n7a0y&hc8^wmru)q^_flty9%!@er'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['127.0.0.1']
 
 
 # Application definition


### PR DESCRIPTION
Hi,

I think dependencies **SHOULD** be used in the last version (at least for interpreted languages).

This `PR` fix `django` -> it **SHOULD** whitelist local ip to run on **production** mode.

Regards,