### PR TITLE
Fix iris

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ gorilla-mux:
 
 iris:
 	go get -u github.com/kataras/iris
-	cd go/iris; go build -o server_go_iris.go
+	cd go/iris; go build -o server_go_iris
 	ln -s -f ../go/iris/server_go_iris bin/.
 
 # fasthttprouter

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ gorilla-mux:
 
 iris:
 	go get -u github.com/kataras/iris
-	cd go/iris; go build -o server_go_iris
+	cd go/iris; go build -o server_go_iris main.go
 	ln -s -f ../go/iris/server_go_iris bin/.
 
 # fasthttprouter


### PR DESCRIPTION
Hi,

When **benchmarking** `go`, it appears that [Iris](https://github.com/kataras/iris) was failing due to wrong symlink.

@tbrand I use **make** to `build`, but I suggest `docker` (#123), at least for now