### PR TITLE
Fix lucky compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ raze:
 
 # Lucky
 lucky:
+	mkdir -p crystal/lucky/public
 	echo '{}' > crystal/lucky/public/manifest.json
 	cd crystal/lucky; bin/setup; shards build --release
 	ln -s -f ../crystal/lucky/bin/server_crystal_lucky bin/.

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ raze:
 
 # Lucky
 lucky:
+	echo '{}' > crystal/lucky/public/manifest.json
 	cd crystal/lucky; bin/setup; shards build --release
 	ln -s -f ../crystal/lucky/bin/server_crystal_lucky bin/.
 


### PR DESCRIPTION
Hi,

[Lucky](https://luckyframework.org/) compilation fails due to static asset compilation, no need in our use case.

@paulcsmith How can we disable it ?

@tbrand This solution works but only using `make`, don't now about `neph`

Regards,