### PR TITLE
Use production mode on Lucky / Raze / Kemal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,14 @@
+######################
+#### ENVIRONMENTS ####
+######################
+
+# Kemal
+export KEMAL_ENV := production
+# Raze
+export CRYSTAL_ENV := prouction
+# Lucky
+export LUCKY_ENV := production
+# Amber
 export AMBER_ENV := production
 
 all: elixir node ruby crystal go rust swift python nim csharp scala client benchmarker


### PR DESCRIPTION
Hi @tbrand,

To specify **production** `mode` usage, we **SHOULD** export environment variable.

I have set those, on `make`.

I don't know :
+ how to set for `neph`
+ if `router.cr` use such a feature

Regards,

This fix #138 