### PR TITLE
Re-enable flask and django

### DIFF
--- a/tools/src/benchmarker.cr
+++ b/tools/src/benchmarker.cr
@@ -59,10 +59,8 @@ LANGS = [
   {lang: "python", targets: [
     {name: "sanic", repo: "channelcat/sanic"},
     {name: "japronto", repo: "squeaky-pl/japronto"},
-    # https://github.com/tbrand/which_is_the_fastest/issues/134
-    # {name: "flask", repo: "pallets/flask"},
-    # It's not working
-    # {name: "django", repo: "django/django"},
+    {name: "flask", repo: "pallets/flask"},
+    {name: "django", repo: "django/django"},
     {name: "tornado", repo: "tornadoweb/tornado"},
   ]},
   {lang: "nim", targets: [


### PR DESCRIPTION
Hi @tbrand,

On https://github.com/tbrand/which_is_the_fastest/blob/6838408b4beb071c1f63b9e1f642b8456964aa08/tools/src/benchmarker.cr you've commented `django` and `flask`.

Was it voluntarily disabled ?

Regards,