### PR TITLE
Do not specify dependencies version

### DIFF
--- a/python/tornado/requirements.txt
+++ b/python/tornado/requirements.txt
@@ -1,1 +1,1 @@
-tornado==4.5.3
+tornado


### PR DESCRIPTION
Hi,

In `tornado`, version was set to **4.5.3**.

However, for our use case (performance benchmarks) specifying version will disabled version update.

Regards,