### PR TITLE
Enable rack-routing via neph

### DIFF
--- a/neph.yaml
+++ b/neph.yaml
@@ -79,6 +79,15 @@ roda:
   dir:
     ruby/roda
 
+rack-routing:
+  command: |
+    bundle update
+    bundle install --path vendor/bundle
+    ln -s -f ../ruby/rack-routing/server_ruby_rack-routing ../../bin/.
+  dir:
+    ruby/rack-routing
+
+
 crystal:
   depends_on:
     - kemal

--- a/tools/src/benchmarker.cr
+++ b/tools/src/benchmarker.cr
@@ -13,7 +13,7 @@ LANGS = [
     {name: "rails", repo: "rails/rails"},
     {name: "sinatra", repo: "sinatra/sinatra"},
     {name: "roda", repo: "jeremyevans/roda"},
-    {name: "rack-routing", repo: "georgeu2000/rack-routing"},
+    {name: "rack-routing", repo: "iAmPlus/rack-routing"},
   ]},
   {lang: "crystal", targets: [
     {name: "kemal", repo: "kemalcr/kemal"},


### PR DESCRIPTION
Hi,

[Rack-routing](https://github.com/iAmPlus/rack-routing) was enabled on `make`.

This `PR` enable it using `neph`

Regards,