### PR TITLE
use regexp to kill background process on node

### DIFF
--- a/tools/src/benchmarker.cr
+++ b/tools/src/benchmarker.cr
@@ -98,7 +98,7 @@ class ExecServer
     elsif @target.lang == "python"
       kill_proc("gunicorn")
     elsif @target.lang == "node"
-      kill_proc("node")
+      kill_proc("node.*js$")
     elsif @target.name == "plug"
       path = File.expand_path("../../../elixir/plug/_build/prod/rel/my_plug/bin/my_plug", __FILE__)
       Process.run("bash #{path} stop", shell: true)
@@ -114,7 +114,7 @@ class ExecServer
 
   def kill_proc(proc : String)
     # Search pid of the process
-    procs = `ps aux | grep #{proc} | grep -v grep`
+    procs = `ps aux | grep -E '#{proc}' | grep -v grep`
     procs.split("\n").each do |proc|
       next if proc.includes?("benchmarker")
       proc.split(" ").each do |pid|


### PR DESCRIPTION
Hi,

`Node` **benchmarks** crashes due because `nodejs` (process) could not be kill after each run.

**Node** is such a common word, I use a regexp to fix this, @see #151.

@tbrand If it's OK for you, I merge this `PR` -> I am not sure if this works on **OS X**

Regards,