### PR TITLE
Avoid (outdated) lock files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,3 +249,5 @@ benchmarker:
 clean:
 	rm -rf bin/*
 	rm -rf *.log
+	find -type f -name '*.lock' -exec rm -fr {} \;
+	find -type f -name package-lock.json -exec rm -fr {} \;


### PR DESCRIPTION
Hi,

On **interpreted** languages :
+ Ruby
+ Node
+ ...
existing (on the system) `lock` **files** could break the benchmarking process.

This `PR` add a `make clean` command to avoid this.

Regards,
