### PR TITLE
Make Ruby use all CPU cores (via Puma workers)

### DIFF
--- a/ruby/rack-routing/Dockerfile
+++ b/ruby/rack-routing/Dockerfile
@@ -11,4 +11,4 @@ RUN bundle install
 
 EXPOSE 3000
 
-CMD [ "bundle", "exec", "rackup", "-p", "3000", "-q", "-E", "production" ]
+CMD bundle exec puma -p 3000 -e production -w $(nproc)

--- a/ruby/rails/Dockerfile
+++ b/ruby/rails/Dockerfile
@@ -12,4 +12,4 @@ RUN bundle install
 
 EXPOSE 3000
 
-CMD ["bin/rails", "s", "-b", "0.0.0.0", "-p", "3000", "-e", "production"]
+CMD bundle exec puma -p 3000 -e production -w $(nproc)

--- a/ruby/rails/config/puma.rb
+++ b/ruby/rails/config/puma.rb
@@ -4,8 +4,8 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
-threads threads_count, threads_count
+# threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+# threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
@@ -13,7 +13,7 @@ port        ENV.fetch("PORT") { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch("RAILS_ENV") { "production" }
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked webserver processes. If using threads and workers together
@@ -22,6 +22,8 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # processes).
 #
 # workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+require 'etc'
+workers Etc.nprocessors
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
@@ -52,4 +54,4 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # end
 
 # Allow puma to be restarted by `rails restart` command.
-plugin :tmp_restart
+# plugin :tmp_restart

--- a/ruby/roda/Dockerfile
+++ b/ruby/roda/Dockerfile
@@ -6,4 +6,4 @@ COPY Gemfile app.rb config.ru ./
 
 RUN bundle install
 
-CMD bundle exec rackup -p 3000 -q -E production
+CMD bundle exec puma -p 3000 -e production -w $(nproc)

--- a/ruby/sinatra/Dockerfile
+++ b/ruby/sinatra/Dockerfile
@@ -6,4 +6,4 @@ COPY Gemfile app.rb config.ru ./
 
 RUN bundle install
 
-CMD bundle exec rackup -p 3000 -q -E production --host 0.0.0.0
+CMD bundle exec puma -p 3000 -e production -w $(nproc)


### PR DESCRIPTION
Related to #69 

It starts many workers for each framework, I tested.

/cc @OvermindDL1 