### PR TITLE
Fix rust version rocket

### DIFF
--- a/rust/rocket/Cargo.toml
+++ b/rust/rocket/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 authors = ["Kilian Koeltzsch <me@kilian.io>"]
 
 [dependencies]
-rocket = "0.3.7"
-rocket_codegen = "0.3.7"
+rocket = "0.3.9"
+rocket_codegen = "0.3.9"

--- a/rust/rocket/Dockerfile
+++ b/rust/rocket/Dockerfile
@@ -2,17 +2,18 @@ FROM rust
 
 WORKDIR /usr/src/app
 
-RUN rustup default nightly
+RUN rustup default nightly-2018-04-28
 RUN rustup update
 
 COPY Cargo.toml ./
 COPY src src
 
-RUN cargo install
-RUN cargo build --release
-
 ENV ROCKET_ENV=production
 
-EXPOSE 3000
+#RUN cargo build --release
 
-CMD target/release/server
+
+#
+#EXPOSE 3000
+#
+#CMD target/release/server


### PR DESCRIPTION
`Rocket` could not compile on **nightly**, I've fix `rustc` to **nightly-2018-04-28**

Fix #204

@SergioBenitez will `rocket` target stable `rust` release in the future ?