### PR TITLE
Fix fastify

### DIFF
--- a/node/fastify/app.js
+++ b/node/fastify/app.js
@@ -23,4 +23,4 @@ app.post('/user', function(request, reply) {
   reply.send()
 })
 
-app.listen(3000, function() {})
+app.listen(3000, '0.0.0.0', function() {})


### PR DESCRIPTION
Fastify run on `127.0.0.1 ` by default, see https://github.com/fastify/fastify#example

Our `benchmark` require to listen on `0.0.0.0`