### PR TITLE
must use compile option "-d:release"

### DIFF
--- a/nim/jester/Dockerfile
+++ b/nim/jester/Dockerfile
@@ -5,6 +5,6 @@ WORKDIR /usr/src/app
 COPY server_nim_jester.nim server_nim_jester.nim.cfg server_nim_jester.nimble ./
 
 RUN nimble install -y
-RUN nim c server_nim_jester.nim
+RUN nim c -d:release server_nim_jester.nim
 
 CMD [ "./server_nim_jester" ]

--- a/nim/mofuw/Dockerfile
+++ b/nim/mofuw/Dockerfile
@@ -5,6 +5,6 @@ WORKDIR /usr/src/app
 COPY server_nim_mofuw.nim server_nim_mofuw.nim.cfg server_nim_mofuw.nimble ./
 
 RUN nimble install -y
-RUN nim c server_nim_mofuw.nim
+RUN nim c -d:release -d:bufSize:512 server_nim_mofuw.nim
 
 CMD [ "./server_nim_mofuw" ]

--- a/nim/mofuw/server_nim_mofuw.nim
+++ b/nim/mofuw/server_nim_mofuw.nim
@@ -23,4 +23,4 @@ proc handler(req: mofuwReq, res: mofuwRes) {.async.} =
         ""
       )
 
-handler.mofuwRun(port = 3000, bufSize = 512)
+handler.mofuwRun(port = 3000)


### PR DESCRIPTION
If "- d: release" is not used, it will be built in debug mode.
It has considerable overhead and performance gets worse.
I want you to redo the benchmark right now...