### PR TITLE
Use wrk as a proper sieger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,18 @@
+addons:
+  apt:
+    update: true
+    packages:
+      - build-essential
+      - libssl-dev
+      - git
+
+
 services: docker
 language: crystal
-before_install: pip install yamllint --user
+before_install: 
+  - pip install yamllint --user
+  - git clone https://github.com/wg/wrk.git /tmp/wrk && cd /tmp/wrk && make && cp wrk ~/bin/ && cd -
+
 install: shards build --release
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,6 @@
-addons:
-  apt:
-    update: true
-    packages:
-      - build-essential
-      - libssl-dev
-      - git
-
-
 services: docker
 language: crystal
-before_install: 
-  - pip install yamllint --user
-  - git clone https://github.com/wg/wrk.git /tmp/wrk && cd /tmp/wrk && make && cp wrk ~/bin/ && cd -
+before_install: pip install yamllint --user
 
 install: shards build --release
 
@@ -39,4 +28,4 @@ script:
   - yamllint neph.yaml
   - yamllint .travis.yml
   - make ${TESTLANG}
-  - bin/benchmarker ${TESTLANG} -r 1
+  - bin/benchmarker ${TESTLANG} --check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 services: docker
 language: crystal
 before_install: pip install yamllint --user
-
 install: shards build --release
 
 env:

--- a/README.md
+++ b/README.md
@@ -8,107 +8,113 @@ Any idea is :heart:, let discuss about it on [![Join the chat at https://gitter.
 ## Result
 
 <!-- Result from here -->
-Last update: 2018-05-12
+Last update: 2018-06-06
 ```
-OS: Linux (version: 4.16.7-200.fc27.x86_64, arch: x86_64)
-CPU Cores: 4
+OS: Linux (version: 4.16.11-100.fc26.x86_64, arch: x86_64)
+CPU Cores: 8
 ```
 
 ### Ranking (Framework)
 
-1. [router.cr](https://github.com/tbrand/router.cr) (crystal)
-2. [raze](https://github.com/samueleaton/raze) (crystal)
-3. [spider-gazelle](https://github.com/spider-gazelle/spider-gazelle) (crystal)
-4. [lucky](https://github.com/luckyframework/lucky) (crystal)
-5. [japronto](https://github.com/squeaky-pl/japronto) (python)
-6. [amber](https://github.com/amberframework/amber) (crystal)
-7. [actix-web](https://github.com/actix/actix-web) (rust)
-8. [kemal](https://github.com/kemalcr/kemal) (crystal)
-9. [fasthttprouter](https://github.com/buaazp/fasthttprouter) (go)
-10. [nickel](https://github.com/nickel-org/nickel.rs) (rust)
-11. [iron](https://github.com/iron/iron) (rust)
-12. [rocket](https://github.com/SergioBenitez/Rocket) (rust)
-13. [iris](https://github.com/kataras/iris) (go)
-14. [echo](https://github.com/labstack/echo) (go)
-15. [gorilla-mux](https://github.com/gorilla/mux) (go)
-16. [polka](https://github.com/lukeed/polka) (node)
-17. [fastify](https://github.com/fastify/fastify) (node)
-18. [aspnetcore](https://github.com/aspnet/Home) (csharp)
-19. [perfect](https://github.com/PerfectlySoft/Perfect) (swift)
-20. [express](https://github.com/expressjs/express) (node)
-21. [vapor](https://github.com/vapor/vapor) (swift)
-22. [akkahttp](https://github.com/akka/akka-http) (scala)
-23. [gin](https://github.com/gin-gonic/gin) (go)
-24. [kitura](https://github.com/IBM-Swift/Kitura) (swift)
-25. [roda](https://github.com/jeremyevans/roda) (ruby)
-26. [rack-routing](https://github.com/iAmPlus/rack-routing) (ruby)
-27. [sanic](https://github.com/channelcat/sanic) (python)
-28. [mofuw](https://github.com/2vg/mofuw) (nim)
-29. [plug](https://github.com/elixir-lang/plug) (elixir)
-30. [phoenix](https://github.com/phoenixframework/phoenix) (elixir)
-31. [flask](https://github.com/pallets/flask) (python)
-32. [flame](https://github.com/AlexWayfer/flame) (ruby)
+1. [fasthttprouter](https://github.com/buaazp/fasthttprouter) (go)
+2. [rocket](https://github.com/SergioBenitez/Rocket) (rust)
+3. [actix-web](https://github.com/actix/actix-web) (rust)
+4. [evhtp](https://github.com/criticalstack/libevhtp) (cpp)
+5. [nickel](https://github.com/nickel-org/nickel.rs) (rust)
+6. [japronto](https://github.com/squeaky-pl/japronto) (python)
+7. [iron](https://github.com/iron/iron) (rust)
+8. [echo](https://github.com/labstack/echo) (go)
+9. [iris](https://github.com/kataras/iris) (go)
+10. [gorilla-mux](https://github.com/gorilla/mux) (go)
+11. [vapor](https://github.com/vapor/vapor) (swift)
+12. [router.cr](https://github.com/tbrand/router.cr) (crystal)
+13. [fastify](https://github.com/fastify/fastify) (node)
+14. [raze](https://github.com/samueleaton/raze) (crystal)
+15. [polka](https://github.com/lukeed/polka) (node)
+16. [plug](https://github.com/elixir-lang/plug) (elixir)
+17. [spider-gazelle](https://github.com/spider-gazelle/spider-gazelle) (crystal)
+18. [act](https://github.com/actframework/actframework) (java)
+19. [amber](https://github.com/amberframework/amber) (crystal)
+20. [roda](https://github.com/jeremyevans/roda) (ruby)
+21. [express](https://github.com/expressjs/express) (node)
+22. [lucky](https://github.com/luckyframework/lucky) (crystal)
+23. [kemal](https://github.com/kemalcr/kemal) (crystal)
+24. [perfect](https://github.com/PerfectlySoft/Perfect) (swift)
+25. [phoenix](https://github.com/phoenixframework/phoenix) (elixir)
+26. [kitura](https://github.com/IBM-Swift/Kitura) (swift)
+27. [aspnetcore](https://github.com/aspnet/Home) (csharp)
+28. [rack-routing](https://github.com/iAmPlus/rack-routing) (ruby)
+29. [sanic](https://github.com/channelcat/sanic) (python)
+30. [flame](https://github.com/AlexWayfer/flame) (ruby)
+31. [akkahttp](https://github.com/akka/akka-http) (scala)
+32. [flask](https://github.com/pallets/flask) (python)
 33. [sinatra](https://github.com/sinatra/sinatra) (ruby)
-34. [jester](https://github.com/dom96/jester) (nim)
-35. [django](https://github.com/django/django) (python)
-36. [tornado](https://github.com/tornadoweb/tornado) (python)
+34. [django](https://github.com/django/django) (python)
+35. [jester](https://github.com/dom96/jester) (nim)
+36. [mofuw](https://github.com/2vg/mofuw) (nim)
 37. [rails](https://github.com/rails/rails) (ruby)
+38. [tornado](https://github.com/tornadoweb/tornado) (python)
+39. [gin](https://github.com/gin-gonic/gin) (go)
 
 ### Ranking (Language)
 
-1. crystal ([router.cr](https://github.com/tbrand/router.cr))
-2. python ([japronto](https://github.com/squeaky-pl/japronto))
-3. rust ([actix-web](https://github.com/actix/actix-web))
-4. go ([fasthttprouter](https://github.com/buaazp/fasthttprouter))
-5. node ([polka](https://github.com/lukeed/polka))
-6. csharp ([aspnetcore](https://github.com/aspnet/Home))
-7. swift ([perfect](https://github.com/PerfectlySoft/Perfect))
-8. scala ([akkahttp](https://github.com/akka/akka-http))
-9. ruby ([roda](https://github.com/jeremyevans/roda))
-10. nim ([mofuw](https://github.com/2vg/mofuw))
-11. elixir ([plug](https://github.com/elixir-lang/plug))
+1. go ([fasthttprouter](https://github.com/buaazp/fasthttprouter))
+2. rust ([rocket](https://github.com/SergioBenitez/Rocket))
+3. cpp ([evhtp](https://github.com/criticalstack/libevhtp))
+4. python ([japronto](https://github.com/squeaky-pl/japronto))
+5. swift ([vapor](https://github.com/vapor/vapor))
+6. crystal ([router.cr](https://github.com/tbrand/router.cr))
+7. node ([fastify](https://github.com/fastify/fastify))
+8. elixir ([plug](https://github.com/elixir-lang/plug))
+9. java ([act](https://github.com/actframework/actframework))
+10. ruby ([roda](https://github.com/jeremyevans/roda))
+11. csharp ([aspnetcore](https://github.com/aspnet/Home))
+12. scala ([akkahttp](https://github.com/akka/akka-http))
+13. nim ([jester](https://github.com/dom96/jester))
 
 ### All frameworks
 
-| Language (Runtime)        | Framework (Middleware)    |       Max [sec] |       Min [sec] |       Ave [sec] |
+| Language (Runtime)        | Framework (Middleware)    |         Minimum |         Maximum |         Average |
 |---------------------------|---------------------------|-----------------|-----------------|-----------------|
-| ruby                      | rails                     |     1138.717029 |      596.705515 |      793.880213 |
-| ruby                      | sinatra                   |      220.587592 |      155.617026 |      192.097094 |
-| ruby                      | roda                      |      105.715563 |       71.388148 |       83.228420 |
-| ruby                      | rack-routing              |      115.894582 |       83.406358 |       98.019375 |
-| ruby                      | flame                     |      227.469019 |      125.581070 |      181.891574 |
-| crystal                   | kemal                     |       30.740479 |       29.321029 |       30.060208 |
-| crystal                   | router.cr                 |       25.867453 |       25.617570 |       25.781999 |
-| crystal                   | raze                      |       26.655143 |       25.705600 |       26.071092 |
-| crystal                   | lucky                     |       28.044076 |       27.428675 |       27.821724 |
-| crystal                   | amber                     |       28.453804 |       28.067356 |       28.264912 |
-| crystal                   | spider-gazelle            |       26.823136 |       26.209777 |       26.620977 |
-| go                        | echo                      |       39.374395 |       38.996778 |       39.165814 |
-| go                        | gorilla-mux               |       39.564056 |       39.280296 |       39.478078 |
-| go                        | iris                      |       39.124244 |       38.538335 |       38.825708 |
-| go                        | fasthttprouter            |       31.302753 |       31.031693 |       31.140474 |
-| go                        | gin                       |       80.046432 |       79.116341 |       79.705716 |
-| rust                      | actix-web                 |       30.083140 |       29.882826 |       29.980387 |
-| rust                      | iron                      |       35.874337 |       35.691640 |       35.788559 |
-| rust                      | nickel                    |       32.189398 |       32.084676 |       32.116358 |
-| rust                      | rocket                    |       37.214242 |       36.793590 |       37.005314 |
-| node                      | express                   |       55.809856 |       55.508365 |       55.700875 |
-| node                      | fastify                   |       51.434494 |       46.757252 |       47.956960 |
-| node                      | polka                     |       42.706277 |       42.024216 |       42.409195 |
-| elixir                    | plug                      |      124.661604 |      122.949471 |      123.807926 |
-| elixir                    | phoenix                   |      146.712690 |      138.679688 |      143.023028 |
-| swift                     | vapor                     |       59.177873 |       58.909018 |       59.048115 |
-| swift                     | perfect                   |       55.277174 |       52.570073 |       54.623487 |
-| swift                     | kitura                    |      100.965082 |       67.449515 |       80.560688 |
-| scala                     | akkahttp                  |       64.114466 |       62.593498 |       63.369870 |
-| csharp                    | aspnetcore                |       51.437905 |       50.897969 |       51.071856 |
-| python                    | sanic                     |      118.590948 |       79.125047 |      101.660033 |
-| python                    | japronto                  |       28.014322 |       27.667655 |       27.879403 |
-| python                    | flask                     |      219.014852 |      114.585625 |      145.897795 |
-| python                    | django                    |      478.203936 |      194.889338 |      271.425040 |
-| python                    | tornado                   |      726.349087 |      706.362335 |      718.087107 |
-| nim                       | jester                    |      246.613563 |      246.253752 |      246.379956 |
-| nim                       | mofuw                     |      147.627614 |       83.375723 |      108.593340 |
+| ruby                      | rails                     |             674 |           60534 |            2405 |
+| ruby                      | sinatra                   |             204 |           27742 |             819 |
+| ruby                      | roda                      |              73 |           18256 |             282 |
+| ruby                      | rack-routing              |              90 |           21269 |             340 |
+| ruby                      | flame                     |             141 |           42077 |             647 |
+| crystal                   | kemal                     |              29 |            5698 |             285 |
+| crystal                   | router.cr                 |              27 |            8791 |             246 |
+| crystal                   | raze                      |              27 |            9522 |             257 |
+| crystal                   | lucky                     |              28 |            7530 |             285 |
+| crystal                   | amber                     |              28 |            6487 |             276 |
+| crystal                   | spider-gazelle            |              26 |            8943 |             269 |
+| go                        | echo                      |              35 |           15384 |             190 |
+| go                        | gorilla-mux               |              33 |           19486 |             222 |
+| go                        | iris                      |              33 |           20959 |             204 |
+| go                        | fasthttprouter            |              23 |           15676 |             120 |
+| go                        | gin                       |              46 |          251860 |            8248 |
+| rust                      | actix-web                 |              26 |           16757 |             163 |
+| rust                      | iron                      |              43 |           15754 |             176 |
+| rust                      | nickel                    |              35 |           16226 |             173 |
+| rust                      | rocket                    |              37 |           16426 |             141 |
+| node                      | express                   |              52 |           29245 |             284 |
+| node                      | fastify                   |              35 |           23115 |             250 |
+| node                      | polka                     |              33 |           30454 |             260 |
+| elixir                    | plug                      |              52 |           10370 |             263 |
+| elixir                    | phoenix                   |              62 |           16288 |             297 |
+| swift                     | vapor                     |              64 |           23145 |             244 |
+| swift                     | perfect                   |              36 |           21161 |             287 |
+| swift                     | kitura                    |              92 |           15020 |             312 |
+| scala                     | akkahttp                  |              51 |          365932 |             652 |
+| csharp                    | aspnetcore                |              47 |          241092 |             317 |
+| python                    | sanic                     |             120 |           17025 |             363 |
+| python                    | japronto                  |              26 |            7221 |             175 |
+| python                    | flask                     |             262 |           18447 |             763 |
+| python                    | django                    |             392 |           29087 |            1124 |
+| python                    | tornado                   |            1100 |           21074 |            6916 |
+| nim                       | jester                    |              56 |           32982 |            1239 |
+| nim                       | mofuw                     |              31 |           88467 |            2339 |
+| java                      | act                       |              28 |          129573 |             275 |
+| cpp                       | evhtp                     |              28 |           16019 |             165 |
 <!-- Result till here -->
 
 ## Current target frameworks (middlewares)

--- a/README.md
+++ b/README.md
@@ -8,113 +8,115 @@ Any idea is :heart:, let discuss about it on [![Join the chat at https://gitter.
 ## Result
 
 <!-- Result from here -->
-Last update: 2018-06-08
+Last update: 2018-06-09
 ```
-OS: Linux (version: 4.16.11-100.fc26.x86_64, arch: x86_64)
-CPU Cores: 8
+OS: Linux (version: 4.16.13-300.fc28.x86_64, arch: x86_64)
+CPU Cores: 4
 ```
 
 ### Ranking (Framework)
 
-1. [evhtp](https://github.com/criticalstack/libevhtp) (cpp)
-2. [actix-web](https://github.com/actix/actix-web) (rust)
-3. [fasthttprouter](https://github.com/buaazp/fasthttprouter) (go)
-4. [mofuw](https://github.com/2vg/mofuw) (nim)
-5. [iron](https://github.com/iron/iron) (rust)
-6. [gorilla-mux](https://github.com/gorilla/mux) (go)
-7. [aspnetcore](https://github.com/aspnet/Home) (csharp)
-8. [echo](https://github.com/labstack/echo) (go)
-9. [rocket](https://github.com/SergioBenitez/Rocket) (rust)
-10. [iris](https://github.com/kataras/iris) (go)
-11. [act](https://github.com/actframework/actframework) (java)
-12. [polka](https://github.com/lukeed/polka) (node)
-13. [nickel](https://github.com/nickel-org/nickel.rs) (rust)
-14. [perfect](https://github.com/PerfectlySoft/Perfect) (swift)
+1. [actix-web](https://github.com/actix/actix-web) (rust)
+2. [fasthttprouter](https://github.com/buaazp/fasthttprouter) (go)
+3. [evhtp](https://github.com/criticalstack/libevhtp) (cpp)
+4. [act](https://github.com/actframework/actframework) (java)
+5. [mofuw](https://github.com/2vg/mofuw) (nim)
+6. [aspnetcore](https://github.com/aspnet/Home) (csharp)
+7. [rocket](https://github.com/SergioBenitez/Rocket) (rust)
+8. [nickel](https://github.com/nickel-org/nickel.rs) (rust)
+9. [iris](https://github.com/kataras/iris) (go)
+10. [iron](https://github.com/iron/iron) (rust)
+11. [gorilla-mux](https://github.com/gorilla/mux) (go)
+12. [echo](https://github.com/labstack/echo) (go)
+13. [rayo](https://github.com/GetRayo/rayo.js) (node)
+14. [polka](https://github.com/lukeed/polka) (node)
 15. [japronto](https://github.com/squeaky-pl/japronto) (python)
-16. [vapor](https://github.com/vapor/vapor) (swift)
-17. [fastify](https://github.com/fastify/fastify) (node)
-18. [roda](https://github.com/jeremyevans/roda) (ruby)
-19. [sanic](https://github.com/channelcat/sanic) (python)
-20. [plug](https://github.com/elixir-lang/plug) (elixir)
-21. [phoenix](https://github.com/phoenixframework/phoenix) (elixir)
-22. [rack-routing](https://github.com/iAmPlus/rack-routing) (ruby)
-23. [spider-gazelle](https://github.com/spider-gazelle/spider-gazelle) (crystal)
-24. [kitura](https://github.com/IBM-Swift/Kitura) (swift)
-25. [router.cr](https://github.com/tbrand/router.cr) (crystal)
-26. [raze](https://github.com/samueleaton/raze) (crystal)
-27. [kemal](https://github.com/kemalcr/kemal) (crystal)
-28. [amber](https://github.com/amberframework/amber) (crystal)
-29. [lucky](https://github.com/luckyframework/lucky) (crystal)
-30. [gin](https://github.com/gin-gonic/gin) (go)
-31. [express](https://github.com/expressjs/express) (node)
-32. [flame](https://github.com/AlexWayfer/flame) (ruby)
-33. [flask](https://github.com/pallets/flask) (python)
+16. [fastify](https://github.com/fastify/fastify) (node)
+17. [perfect](https://github.com/PerfectlySoft/Perfect) (swift)
+18. [akkahttp](https://github.com/akka/akka-http) (scala)
+19. [router.cr](https://github.com/tbrand/router.cr) (crystal)
+20. [raze](https://github.com/samueleaton/raze) (crystal)
+21. [spider-gazelle](https://github.com/spider-gazelle/spider-gazelle) (crystal)
+22. [vapor](https://github.com/vapor/vapor) (swift)
+23. [lucky](https://github.com/luckyframework/lucky) (crystal)
+24. [amber](https://github.com/amberframework/amber) (crystal)
+25. [kemal](https://github.com/kemalcr/kemal) (crystal)
+26. [sanic](https://github.com/channelcat/sanic) (python)
+27. [plug](https://github.com/elixir-lang/plug) (elixir)
+28. [express](https://github.com/expressjs/express) (node)
+29. [gin](https://github.com/gin-gonic/gin) (go)
+30. [kitura](https://github.com/IBM-Swift/Kitura) (swift)
+31. [roda](https://github.com/jeremyevans/roda) (ruby)
+32. [phoenix](https://github.com/phoenixframework/phoenix) (elixir)
+33. [rack-routing](https://github.com/iAmPlus/rack-routing) (ruby)
 34. [jester](https://github.com/dom96/jester) (nim)
-35. [sinatra](https://github.com/sinatra/sinatra) (ruby)
-36. [django](https://github.com/django/django) (python)
-37. [akkahttp](https://github.com/akka/akka-http) (scala)
-38. [rails](https://github.com/rails/rails) (ruby)
-39. [tornado](https://github.com/tornadoweb/tornado) (python)
+35. [flame](https://github.com/AlexWayfer/flame) (ruby)
+36. [flask](https://github.com/pallets/flask) (python)
+37. [sinatra](https://github.com/sinatra/sinatra) (ruby)
+38. [django](https://github.com/django/django) (python)
+39. [rails](https://github.com/rails/rails) (ruby)
+40. [tornado](https://github.com/tornadoweb/tornado) (python)
 
 ### Ranking (Language)
 
-1. cpp ([evhtp](https://github.com/criticalstack/libevhtp))
-2. rust ([actix-web](https://github.com/actix/actix-web))
-3. go ([fasthttprouter](https://github.com/buaazp/fasthttprouter))
-4. nim ([mofuw](https://github.com/2vg/mofuw))
-5. csharp ([aspnetcore](https://github.com/aspnet/Home))
-6. java ([act](https://github.com/actframework/actframework))
-7. node ([polka](https://github.com/lukeed/polka))
-8. swift ([perfect](https://github.com/PerfectlySoft/Perfect))
-9. python ([japronto](https://github.com/squeaky-pl/japronto))
-10. ruby ([roda](https://github.com/jeremyevans/roda))
-11. elixir ([plug](https://github.com/elixir-lang/plug))
-12. crystal ([spider-gazelle](https://github.com/spider-gazelle/spider-gazelle))
-13. scala ([akkahttp](https://github.com/akka/akka-http))
+1. rust ([actix-web](https://github.com/actix/actix-web))
+2. go ([fasthttprouter](https://github.com/buaazp/fasthttprouter))
+3. cpp ([evhtp](https://github.com/criticalstack/libevhtp))
+4. java ([act](https://github.com/actframework/actframework))
+5. nim ([mofuw](https://github.com/2vg/mofuw))
+6. csharp ([aspnetcore](https://github.com/aspnet/Home))
+7. node ([rayo](https://github.com/GetRayo/rayo.js))
+8. python ([japronto](https://github.com/squeaky-pl/japronto))
+9. swift ([perfect](https://github.com/PerfectlySoft/Perfect))
+10. scala ([akkahttp](https://github.com/akka/akka-http))
+11. crystal ([router.cr](https://github.com/tbrand/router.cr))
+12. elixir ([plug](https://github.com/elixir-lang/plug))
+13. ruby ([roda](https://github.com/jeremyevans/roda))
 
 ### All frameworks
 
-| Language (Runtime)        | Framework (Middleware)    |          Errors |    Requests / s |      Throughput |
-|---------------------------|---------------------------|-----------------|-----------------|-----------------|
-| ruby                      | rails                     |               0 |          5244.0 |          0.88MB |
-| ruby                      | sinatra                   |               0 |        18319.21 |          3.00MB |
-| ruby                      | roda                      |               0 |        51746.05 |          3.11MB |
-| ruby                      | rack-routing              |               0 |        38970.56 |          1.41MB |
-| ruby                      | flame                     |               0 |        20051.54 |        744.10KB |
-| crystal                   | kemal                     |               0 |        30853.43 |          3.18MB |
-| crystal                   | router.cr                 |               0 |        36430.32 |          2.15MB |
-| crystal                   | raze                      |               0 |        33763.82 |          2.00MB |
-| crystal                   | lucky                     |               0 |        29881.06 |          2.22MB |
-| crystal                   | amber                     |               0 |        30195.57 |          2.76MB |
-| crystal                   | spider-gazelle            |               0 |        37697.55 |          2.23MB |
-| go                        | echo                      |               0 |        96148.61 |         10.64MB |
-| go                        | gorilla-mux               |               0 |       104014.08 |          7.44MB |
-| go                        | iris                      |               0 |         88321.3 |          6.32MB |
-| go                        | fasthttprouter            |               0 |       155974.14 |         13.83MB |
-| go                        | gin                       |               0 |        28294.89 |          3.13MB |
-| rust                      | actix-web                 |               0 |       182784.28 |         13.07MB |
-| rust                      | iron                      |               0 |       104671.44 |          7.49MB |
-| rust                      | nickel                    |               0 |        75911.41 |          9.41MB |
-| rust                      | rocket                    |               0 |         92901.0 |          8.06MB |
-| node                      | express                   |               0 |        24262.72 |          3.75MB |
-| node                      | fastify                   |               0 |        53698.26 |          5.07MB |
-| node                      | polka                     |               0 |        76523.19 |          7.22MB |
-| elixir                    | plug                      |               0 |        47695.39 |          6.50MB |
-| elixir                    | phoenix                   |               0 |        41442.85 |          5.65MB |
-| swift                     | vapor                     |               0 |        54414.23 |          3.89MB |
-| swift                     | perfect                   |               0 |        73990.89 |          4.37MB |
-| swift                     | kitura                    |               0 |        36446.95 |          4.28MB |
-| scala                     | akkahttp                  |               0 |         9815.91 |          1.33MB |
-| csharp                    | aspnetcore                |               0 |        103493.5 |         10.46MB |
-| python                    | sanic                     |               0 |        50452.43 |          5.73MB |
-| python                    | japronto                  |               0 |        55134.46 |          4.15MB |
-| python                    | flask                     |               0 |        19839.14 |          3.08MB |
-| python                    | django                    |               0 |        12533.96 |          2.30MB |
-| python                    | tornado                   |               0 |         1309.27 |        248.04KB |
-| nim                       | jester                    |               0 |        19409.12 |          1.43MB |
-| nim                       | mofuw                     |               0 |       114043.75 |         12.94MB |
-| java                      | act                       |               0 |        77115.44 |          8.31MB |
-| cpp                       | evhtp                     |               0 |       185815.53 |         11.34MB |
+| Language (Runtime)        | Framework (Middleware)    |    Requests / s |         Latency |   99 percentile |      Throughput |
+|---------------------------|---------------------------|-----------------|-----------------|-----------------|------------|
+| ruby                      | rails                     | 4671.00 | 13635.00 | 4671.00 | 12294975.00 |
+| ruby                      | sinatra                   | 16360.00 | 3895.00 | 16360.00 | 42332812.00 |
+| ruby                      | roda                      | 41646.00 | 1564.00 | 41646.00 | 39497535.00 |
+| ruby                      | rack-routing              | 35602.00 | 1844.00 | 35602.00 | 20332166.00 |
+| ruby                      | flame                     | 21293.00 | 2996.00 | 21293.00 | 12160798.00 |
+| crystal                   | kemal                     | 49671.00 | 25229.00 | 49671.00 | 80745876.00 |
+| crystal                   | router.cr                 | 58447.00 | 22666.00 | 58447.00 | 54521808.00 |
+| crystal                   | raze                      | 56666.00 | 16379.00 | 56666.00 | 52833238.00 |
+| crystal                   | lucky                     | 51648.00 | 18086.00 | 51648.00 | 60642972.00 |
+| crystal                   | amber                     | 51092.00 | 25468.00 | 51092.00 | 73752768.00 |
+| crystal                   | spider-gazelle            | 55877.00 | 23902.00 | 55877.00 | 52121168.00 |
+| go                        | echo                      | 94024.00 | 14954.00 | 94024.00 | 164513520.00 |
+| go                        | gorilla-mux               | 94646.00 | 13784.00 | 94646.00 | 106942500.00 |
+| go                        | iris                      | 98817.00 | 14056.00 | 98817.00 | 111828300.00 |
+| go                        | fasthttprouter            | 169565.00 | 5559.00 | 169565.00 | 238026804.00 |
+| go                        | gin                       | 47558.00 | 25434.00 | 47558.00 | 82946960.00 |
+| rust                      | actix-web                 | 193879.00 | 4191.00 | 193879.00 | 219329775.00 |
+| rust                      | iron                      | 95837.00 | 332.00 | 95837.00 | 108278100.00 |
+| rust                      | nickel                    | 102210.00 | 43.00 | 102210.00 | 200015270.00 |
+| rust                      | rocket                    | 122714.00 | 59.00 | 122714.00 | 167994372.00 |
+| node                      | express                   | 47784.00 | 54772.00 | 47784.00 | 116402508.00 |
+| node                      | fastify                   | 79264.00 | 25406.00 | 79264.00 | 118486467.00 |
+| node                      | polka                     | 86485.00 | 25475.00 | 86485.00 | 129264399.00 |
+| node                      | rayo                      | 87524.00 | 17997.00 | 87524.00 | 130716531.00 |
+| elixir                    | plug                      | 48058.00 | 31029.00 | 48058.00 | 103417314.00 |
+| elixir                    | phoenix                   | 40106.00 | 33881.00 | 40106.00 | 86289918.00 |
+| swift                     | vapor                     | 52345.00 | 23773.00 | 52345.00 | 59041500.00 |
+| swift                     | perfect                   | 75254.00 | 12607.00 | 75254.00 | 70296778.00 |
+| swift                     | kitura                    | 46715.00 | 20010.00 | 46715.00 | 86426565.00 |
+| scala                     | akkahttp                  | 64771.00 | 211582.00 | 64771.00 | 138398028.00 |
+| csharp                    | aspnetcore                | 124906.00 | 7263.00 | 124906.00 | 199594502.00 |
+| python                    | sanic                     | 48279.00 | 19313.00 | 48279.00 | 86582615.00 |
+| python                    | japronto                  | 80969.00 | 11445.00 | 80969.00 | 96254864.00 |
+| python                    | flask                     | 17241.00 | 60640.00 | 17241.00 | 42363537.00 |
+| python                    | django                    | 12039.00 | 80415.00 | 12039.00 | 34764480.00 |
+| python                    | tornado                   | 2098.00 | 466380.00 | 2098.00 | 6122446.00 |
+| nim                       | jester                    | 30245.00 | 56324.00 | 30245.00 | 35036232.00 |
+| nim                       | mofuw                     | 139689.00 | 7925.00 | 139689.00 | 250877228.00 |
+| java                      | act                       | 154129.00 | 9661.00 | 154129.00 | 262951678.00 |
+| cpp                       | evhtp                     | 165218.00 | 5296.00 | 165218.00 | 159617920.00 |
 <!-- Result till here -->
 
 ## The rule

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Any idea is :heart:, let discuss about it on [![Join the chat at https://gitter.
 ## Result
 
 <!-- Result from here -->
-Last update: 2018-06-09
+Last update: 2018-06-10
 ```
-OS: Linux (version: 4.16.13-300.fc28.x86_64, arch: x86_64)
+OS: Linux (version: 4.16.14-300.fc28.x86_64, arch: x86_64)
 CPU Cores: 4
 ```
 
@@ -26,32 +26,32 @@ CPU Cores: 4
 8. [nickel](https://github.com/nickel-org/nickel.rs) (rust)
 9. [iris](https://github.com/kataras/iris) (go)
 10. [iron](https://github.com/iron/iron) (rust)
-11. [gorilla-mux](https://github.com/gorilla/mux) (go)
-12. [echo](https://github.com/labstack/echo) (go)
-13. [rayo](https://github.com/GetRayo/rayo.js) (node)
+11. [echo](https://github.com/labstack/echo) (go)
+12. [gorilla-mux](https://github.com/gorilla/mux) (go)
+13. [japronto](https://github.com/squeaky-pl/japronto) (python)
 14. [polka](https://github.com/lukeed/polka) (node)
-15. [japronto](https://github.com/squeaky-pl/japronto) (python)
-16. [fastify](https://github.com/fastify/fastify) (node)
-17. [perfect](https://github.com/PerfectlySoft/Perfect) (swift)
-18. [akkahttp](https://github.com/akka/akka-http) (scala)
-19. [router.cr](https://github.com/tbrand/router.cr) (crystal)
-20. [raze](https://github.com/samueleaton/raze) (crystal)
-21. [spider-gazelle](https://github.com/spider-gazelle/spider-gazelle) (crystal)
-22. [vapor](https://github.com/vapor/vapor) (swift)
-23. [lucky](https://github.com/luckyframework/lucky) (crystal)
-24. [amber](https://github.com/amberframework/amber) (crystal)
-25. [kemal](https://github.com/kemalcr/kemal) (crystal)
-26. [sanic](https://github.com/channelcat/sanic) (python)
-27. [plug](https://github.com/elixir-lang/plug) (elixir)
-28. [express](https://github.com/expressjs/express) (node)
-29. [gin](https://github.com/gin-gonic/gin) (go)
-30. [kitura](https://github.com/IBM-Swift/Kitura) (swift)
-31. [roda](https://github.com/jeremyevans/roda) (ruby)
-32. [phoenix](https://github.com/phoenixframework/phoenix) (elixir)
+15. [rayo](https://github.com/GetRayo/rayo.js) (node)
+16. [akkahttp](https://github.com/akka/akka-http) (scala)
+17. [fastify](https://github.com/fastify/fastify) (node)
+18. [perfect](https://github.com/PerfectlySoft/Perfect) (swift)
+19. [raze](https://github.com/samueleaton/raze) (crystal)
+20. [router.cr](https://github.com/tbrand/router.cr) (crystal)
+21. [sanic](https://github.com/channelcat/sanic) (python)
+22. [express](https://github.com/expressjs/express) (node)
+23. [spider-gazelle](https://github.com/spider-gazelle/spider-gazelle) (crystal)
+24. [vapor](https://github.com/vapor/vapor) (swift)
+25. [lucky](https://github.com/luckyframework/lucky) (crystal)
+26. [plug](https://github.com/elixir-lang/plug) (elixir)
+27. [kitura](https://github.com/IBM-Swift/Kitura) (swift)
+28. [amber](https://github.com/amberframework/amber) (crystal)
+29. [kemal](https://github.com/kemalcr/kemal) (crystal)
+30. [roda](https://github.com/jeremyevans/roda) (ruby)
+31. [phoenix](https://github.com/phoenixframework/phoenix) (elixir)
+32. [gin](https://github.com/gin-gonic/gin) (go)
 33. [rack-routing](https://github.com/iAmPlus/rack-routing) (ruby)
 34. [jester](https://github.com/dom96/jester) (nim)
-35. [flame](https://github.com/AlexWayfer/flame) (ruby)
-36. [flask](https://github.com/pallets/flask) (python)
+35. [flask](https://github.com/pallets/flask) (python)
+36. [flame](https://github.com/AlexWayfer/flame) (ruby)
 37. [sinatra](https://github.com/sinatra/sinatra) (ruby)
 38. [django](https://github.com/django/django) (python)
 39. [rails](https://github.com/rails/rails) (ruby)
@@ -65,58 +65,58 @@ CPU Cores: 4
 4. java ([act](https://github.com/actframework/actframework))
 5. nim ([mofuw](https://github.com/2vg/mofuw))
 6. csharp ([aspnetcore](https://github.com/aspnet/Home))
-7. node ([rayo](https://github.com/GetRayo/rayo.js))
-8. python ([japronto](https://github.com/squeaky-pl/japronto))
-9. swift ([perfect](https://github.com/PerfectlySoft/Perfect))
-10. scala ([akkahttp](https://github.com/akka/akka-http))
-11. crystal ([router.cr](https://github.com/tbrand/router.cr))
+7. python ([japronto](https://github.com/squeaky-pl/japronto))
+8. node ([polka](https://github.com/lukeed/polka))
+9. scala ([akkahttp](https://github.com/akka/akka-http))
+10. swift ([perfect](https://github.com/PerfectlySoft/Perfect))
+11. crystal ([raze](https://github.com/samueleaton/raze))
 12. elixir ([plug](https://github.com/elixir-lang/plug))
 13. ruby ([roda](https://github.com/jeremyevans/roda))
 
 ### All frameworks
 
 | Language (Runtime)        | Framework (Middleware)    |    Requests / s |         Latency |   99 percentile |      Throughput |
-|---------------------------|---------------------------|-----------------|-----------------|-----------------|------------|
-| ruby                      | rails                     | 4671.00 | 13635.00 | 4671.00 | 12294975.00 |
-| ruby                      | sinatra                   | 16360.00 | 3895.00 | 16360.00 | 42332812.00 |
-| ruby                      | roda                      | 41646.00 | 1564.00 | 41646.00 | 39497535.00 |
-| ruby                      | rack-routing              | 35602.00 | 1844.00 | 35602.00 | 20332166.00 |
-| ruby                      | flame                     | 21293.00 | 2996.00 | 21293.00 | 12160798.00 |
-| crystal                   | kemal                     | 49671.00 | 25229.00 | 49671.00 | 80745876.00 |
-| crystal                   | router.cr                 | 58447.00 | 22666.00 | 58447.00 | 54521808.00 |
-| crystal                   | raze                      | 56666.00 | 16379.00 | 56666.00 | 52833238.00 |
-| crystal                   | lucky                     | 51648.00 | 18086.00 | 51648.00 | 60642972.00 |
-| crystal                   | amber                     | 51092.00 | 25468.00 | 51092.00 | 73752768.00 |
-| crystal                   | spider-gazelle            | 55877.00 | 23902.00 | 55877.00 | 52121168.00 |
-| go                        | echo                      | 94024.00 | 14954.00 | 94024.00 | 164513520.00 |
-| go                        | gorilla-mux               | 94646.00 | 13784.00 | 94646.00 | 106942500.00 |
-| go                        | iris                      | 98817.00 | 14056.00 | 98817.00 | 111828300.00 |
-| go                        | fasthttprouter            | 169565.00 | 5559.00 | 169565.00 | 238026804.00 |
-| go                        | gin                       | 47558.00 | 25434.00 | 47558.00 | 82946960.00 |
-| rust                      | actix-web                 | 193879.00 | 4191.00 | 193879.00 | 219329775.00 |
-| rust                      | iron                      | 95837.00 | 332.00 | 95837.00 | 108278100.00 |
-| rust                      | nickel                    | 102210.00 | 43.00 | 102210.00 | 200015270.00 |
-| rust                      | rocket                    | 122714.00 | 59.00 | 122714.00 | 167994372.00 |
-| node                      | express                   | 47784.00 | 54772.00 | 47784.00 | 116402508.00 |
-| node                      | fastify                   | 79264.00 | 25406.00 | 79264.00 | 118486467.00 |
-| node                      | polka                     | 86485.00 | 25475.00 | 86485.00 | 129264399.00 |
-| node                      | rayo                      | 87524.00 | 17997.00 | 87524.00 | 130716531.00 |
-| elixir                    | plug                      | 48058.00 | 31029.00 | 48058.00 | 103417314.00 |
-| elixir                    | phoenix                   | 40106.00 | 33881.00 | 40106.00 | 86289918.00 |
-| swift                     | vapor                     | 52345.00 | 23773.00 | 52345.00 | 59041500.00 |
-| swift                     | perfect                   | 75254.00 | 12607.00 | 75254.00 | 70296778.00 |
-| swift                     | kitura                    | 46715.00 | 20010.00 | 46715.00 | 86426565.00 |
-| scala                     | akkahttp                  | 64771.00 | 211582.00 | 64771.00 | 138398028.00 |
-| csharp                    | aspnetcore                | 124906.00 | 7263.00 | 124906.00 | 199594502.00 |
-| python                    | sanic                     | 48279.00 | 19313.00 | 48279.00 | 86582615.00 |
-| python                    | japronto                  | 80969.00 | 11445.00 | 80969.00 | 96254864.00 |
-| python                    | flask                     | 17241.00 | 60640.00 | 17241.00 | 42363537.00 |
-| python                    | django                    | 12039.00 | 80415.00 | 12039.00 | 34764480.00 |
-| python                    | tornado                   | 2098.00 | 466380.00 | 2098.00 | 6122446.00 |
-| nim                       | jester                    | 30245.00 | 56324.00 | 30245.00 | 35036232.00 |
-| nim                       | mofuw                     | 139689.00 | 7925.00 | 139689.00 | 250877228.00 |
-| java                      | act                       | 154129.00 | 9661.00 | 154129.00 | 262951678.00 |
-| cpp                       | evhtp                     | 165218.00 | 5296.00 | 165218.00 | 159617920.00 |
+|---------------------------|---------------------------|----------------:|:----------------:|----------------:|-----------:|
+| ruby                      | rails                     | 4372.00 | 14636.33 | 96833.67 | 3979380.33 |
+| ruby                      | sinatra                   | 16246.67 | 3922.00 | 45670.33 | 13920038.67 |
+| ruby                      | roda                      | 38623.67 | 1715.33 | 30815.67 | 12687448.67 |
+| ruby                      | rack-routing              | 29904.67 | 2278.33 | 37652.00 | 5907377.33 |
+| ruby                      | flame                     | 17468.00 | 3701.33 | 47760.33 | 3340251.33 |
+| crystal                   | kemal                     | 40110.67 | 23705.67 | 33775.00 | 19304178.67 |
+| crystal                   | router.cr                 | 51950.67 | 18357.33 | 24785.00 | 14798754.00 |
+| crystal                   | raze                      | 54512.67 | 20082.33 | 125983.67 | 16769547.33 |
+| crystal                   | lucky                     | 44838.00 | 21376.67 | 26056.67 | 15899976.00 |
+| crystal                   | amber                     | 41827.33 | 25088.67 | 95390.33 | 16906595.33 |
+| crystal                   | spider-gazelle            | 46736.67 | 20296.67 | 25062.00 | 12927898.00 |
+| go                        | echo                      | 90506.00 | 14453.00 | 129697.33 | 52181620.67 |
+| go                        | gorilla-mux               | 86871.67 | 14802.00 | 125746.00 | 32838546.67 |
+| go                        | iris                      | 96267.00 | 15078.00 | 174130.00 | 35769067.00 |
+| go                        | fasthttprouter            | 160652.33 | 6156.33 | 53915.67 | 73558143.33 |
+| go                        | gin                       | 36927.67 | 31137.33 | 148275.67 | 20709597.00 |
+| rust                      | actix-web                 | 188240.67 | 4367.33 | 15139.00 | 70870040.67 |
+| rust                      | iron                      | 95394.33 | 321.67 | 1094.67 | 35548869.33 |
+| rust                      | nickel                    | 104670.00 | 42.33 | 50.33 | 68611160.00 |
+| rust                      | rocket                    | 107608.67 | 68.33 | 159.00 | 49859189.33 |
+| node                      | express                   | 47823.00 | 37230.33 | 730944.33 | 39938433.00 |
+| node                      | fastify                   | 66100.67 | 27589.33 | 534516.33 | 66311172.00 |
+| node                      | polka                     | 77566.33 | 17744.67 | 232930.33 | 38042086.33 |
+| node                      | rayo                      | 76513.67 | 18590.00 | 263289.00 | 37589230.67 |
+| elixir                    | plug                      | 43648.67 | 33837.00 | 243430.67 | 29272801.00 |
+| elixir                    | phoenix                   | 38188.33 | 36290.33 | 232460.67 | 25718128.33 |
+| swift                     | vapor                     | 46053.33 | 51436.67 | 1166803.00 | 16522653.33 |
+| swift                     | perfect                   | 65855.67 | 14834.67 | 17608.67 | 16999461.00 |
+| swift                     | kitura                    | 42926.00 | 22127.67 | 37097.67 | 26409534.00 |
+| scala                     | akkahttp                  | 69245.00 | 230129.33 | 5289308.67 | 53127119.00 |
+| csharp                    | aspnetcore                | 117176.00 | 8602.67 | 17974.67 | 61599543.33 |
+| python                    | sanic                     | 48795.00 | 19507.00 | 36879.67 | 29155520.67 |
+| python                    | japronto                  | 86765.67 | 11057.00 | 11265.33 | 35608694.33 |
+| python                    | flask                     | 18775.00 | 50920.33 | 101835.33 | 15377015.33 |
+| python                    | django                    | 11025.67 | 89173.00 | 263761.00 | 10375313.67 |
+| python                    | tornado                   | 1910.67 | 490938.33 | 2724463.00 | 1349414.67 |
+| nim                       | jester                    | 28754.33 | 66472.00 | 1262444.67 | 10469903.00 |
+| nim                       | mofuw                     | 131842.67 | 8788.33 | 51147.67 | 80210274.67 |
+| java                      | act                       | 138188.00 | 8296.67 | 53235.33 | 73474924.33 |
+| cpp                       | evhtp                     | 158545.00 | 5397.67 | 13185.67 | 50781478.33 |
 <!-- Result till here -->
 
 ## The rule

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Any idea is :heart:, let discuss about it on [![Join the chat at https://gitter.
 ## Result
 
 <!-- Result from here -->
-Last update: 2018-06-10
+Last update: 2018-06-11
 ```
-OS: Linux (version: 4.16.14-300.fc28.x86_64, arch: x86_64)
-CPU Cores: 4
+OS: Linux (version: 4.16.11-100.fc26.x86_64, arch: x86_64)
+CPU Cores: 8
+threads: 9, requests: 100000.0
 ```
 
 ### Ranking (Framework)
@@ -19,104 +20,102 @@ CPU Cores: 4
 1. [actix-web](https://github.com/actix/actix-web) (rust)
 2. [fasthttprouter](https://github.com/buaazp/fasthttprouter) (go)
 3. [evhtp](https://github.com/criticalstack/libevhtp) (cpp)
-4. [act](https://github.com/actframework/actframework) (java)
-5. [mofuw](https://github.com/2vg/mofuw) (nim)
-6. [aspnetcore](https://github.com/aspnet/Home) (csharp)
-7. [rocket](https://github.com/SergioBenitez/Rocket) (rust)
-8. [nickel](https://github.com/nickel-org/nickel.rs) (rust)
-9. [iris](https://github.com/kataras/iris) (go)
-10. [iron](https://github.com/iron/iron) (rust)
-11. [echo](https://github.com/labstack/echo) (go)
-12. [gorilla-mux](https://github.com/gorilla/mux) (go)
-13. [japronto](https://github.com/squeaky-pl/japronto) (python)
-14. [polka](https://github.com/lukeed/polka) (node)
-15. [rayo](https://github.com/GetRayo/rayo.js) (node)
-16. [akkahttp](https://github.com/akka/akka-http) (scala)
-17. [fastify](https://github.com/fastify/fastify) (node)
-18. [perfect](https://github.com/PerfectlySoft/Perfect) (swift)
-19. [raze](https://github.com/samueleaton/raze) (crystal)
-20. [router.cr](https://github.com/tbrand/router.cr) (crystal)
+4. [mofuw](https://github.com/2vg/mofuw) (nim)
+5. [act](https://github.com/actframework/actframework) (java)
+6. [iris](https://github.com/kataras/iris) (go)
+7. [echo](https://github.com/labstack/echo) (go)
+8. [gorilla-mux](https://github.com/gorilla/mux) (go)
+9. [iron](https://github.com/iron/iron) (rust)
+10. [rocket](https://github.com/SergioBenitez/Rocket) (rust)
+11. [aspnetcore](https://github.com/aspnet/Home) (csharp)
+12. [polka](https://github.com/lukeed/polka) (node)
+13. [nickel](https://github.com/nickel-org/nickel.rs) (rust)
+14. [fastify](https://github.com/fastify/fastify) (node)
+15. [perfect](https://github.com/PerfectlySoft/Perfect) (swift)
+16. [roda](https://github.com/jeremyevans/roda) (ruby)
+17. [vapor](https://github.com/vapor/vapor) (swift)
+18. [plug](https://github.com/elixir-lang/plug) (elixir)
+19. [japronto](https://github.com/squeaky-pl/japronto) (python)
+20. [express](https://github.com/expressjs/express) (node)
 21. [sanic](https://github.com/channelcat/sanic) (python)
-22. [express](https://github.com/expressjs/express) (node)
-23. [spider-gazelle](https://github.com/spider-gazelle/spider-gazelle) (crystal)
-24. [vapor](https://github.com/vapor/vapor) (swift)
-25. [lucky](https://github.com/luckyframework/lucky) (crystal)
-26. [plug](https://github.com/elixir-lang/plug) (elixir)
+22. [router.cr](https://github.com/tbrand/router.cr) (crystal)
+23. [akkahttp](https://github.com/akka/akka-http) (scala)
+24. [rack-routing](https://github.com/iAmPlus/rack-routing) (ruby)
+25. [phoenix](https://github.com/phoenixframework/phoenix) (elixir)
+26. [raze](https://github.com/samueleaton/raze) (crystal)
 27. [kitura](https://github.com/IBM-Swift/Kitura) (swift)
-28. [amber](https://github.com/amberframework/amber) (crystal)
-29. [kemal](https://github.com/kemalcr/kemal) (crystal)
-30. [roda](https://github.com/jeremyevans/roda) (ruby)
-31. [phoenix](https://github.com/phoenixframework/phoenix) (elixir)
-32. [gin](https://github.com/gin-gonic/gin) (go)
-33. [rack-routing](https://github.com/iAmPlus/rack-routing) (ruby)
-34. [jester](https://github.com/dom96/jester) (nim)
-35. [flask](https://github.com/pallets/flask) (python)
-36. [flame](https://github.com/AlexWayfer/flame) (ruby)
-37. [sinatra](https://github.com/sinatra/sinatra) (ruby)
-38. [django](https://github.com/django/django) (python)
-39. [rails](https://github.com/rails/rails) (ruby)
-40. [tornado](https://github.com/tornadoweb/tornado) (python)
+28. [spider-gazelle](https://github.com/spider-gazelle/spider-gazelle) (crystal)
+29. [gin](https://github.com/gin-gonic/gin) (go)
+30. [lucky](https://github.com/luckyframework/lucky) (crystal)
+31. [kemal](https://github.com/kemalcr/kemal) (crystal)
+32. [amber](https://github.com/amberframework/amber) (crystal)
+33. [flame](https://github.com/AlexWayfer/flame) (ruby)
+34. [sinatra](https://github.com/sinatra/sinatra) (ruby)
+35. [jester](https://github.com/dom96/jester) (nim)
+36. [flask](https://github.com/pallets/flask) (python)
+37. [django](https://github.com/django/django) (python)
+38. [rails](https://github.com/rails/rails) (ruby)
+39. [tornado](https://github.com/tornadoweb/tornado) (python)
 
 ### Ranking (Language)
 
 1. rust ([actix-web](https://github.com/actix/actix-web))
 2. go ([fasthttprouter](https://github.com/buaazp/fasthttprouter))
 3. cpp ([evhtp](https://github.com/criticalstack/libevhtp))
-4. java ([act](https://github.com/actframework/actframework))
-5. nim ([mofuw](https://github.com/2vg/mofuw))
+4. nim ([mofuw](https://github.com/2vg/mofuw))
+5. java ([act](https://github.com/actframework/actframework))
 6. csharp ([aspnetcore](https://github.com/aspnet/Home))
-7. python ([japronto](https://github.com/squeaky-pl/japronto))
-8. node ([polka](https://github.com/lukeed/polka))
-9. scala ([akkahttp](https://github.com/akka/akka-http))
-10. swift ([perfect](https://github.com/PerfectlySoft/Perfect))
-11. crystal ([raze](https://github.com/samueleaton/raze))
-12. elixir ([plug](https://github.com/elixir-lang/plug))
-13. ruby ([roda](https://github.com/jeremyevans/roda))
+7. node ([polka](https://github.com/lukeed/polka))
+8. swift ([perfect](https://github.com/PerfectlySoft/Perfect))
+9. ruby ([roda](https://github.com/jeremyevans/roda))
+10. elixir ([plug](https://github.com/elixir-lang/plug))
+11. python ([japronto](https://github.com/squeaky-pl/japronto))
+12. crystal ([router.cr](https://github.com/tbrand/router.cr))
+13. scala ([akkahttp](https://github.com/akka/akka-http))
 
 ### All frameworks
 
 | Language (Runtime)        | Framework (Middleware)    |    Requests / s |         Latency |   99 percentile |      Throughput |
-|---------------------------|---------------------------|----------------:|:----------------:|----------------:|-----------:|
-| ruby                      | rails                     | 4372.00 | 14636.33 | 96833.67 | 3979380.33 |
-| ruby                      | sinatra                   | 16246.67 | 3922.00 | 45670.33 | 13920038.67 |
-| ruby                      | roda                      | 38623.67 | 1715.33 | 30815.67 | 12687448.67 |
-| ruby                      | rack-routing              | 29904.67 | 2278.33 | 37652.00 | 5907377.33 |
-| ruby                      | flame                     | 17468.00 | 3701.33 | 47760.33 | 3340251.33 |
-| crystal                   | kemal                     | 40110.67 | 23705.67 | 33775.00 | 19304178.67 |
-| crystal                   | router.cr                 | 51950.67 | 18357.33 | 24785.00 | 14798754.00 |
-| crystal                   | raze                      | 54512.67 | 20082.33 | 125983.67 | 16769547.33 |
-| crystal                   | lucky                     | 44838.00 | 21376.67 | 26056.67 | 15899976.00 |
-| crystal                   | amber                     | 41827.33 | 25088.67 | 95390.33 | 16906595.33 |
-| crystal                   | spider-gazelle            | 46736.67 | 20296.67 | 25062.00 | 12927898.00 |
-| go                        | echo                      | 90506.00 | 14453.00 | 129697.33 | 52181620.67 |
-| go                        | gorilla-mux               | 86871.67 | 14802.00 | 125746.00 | 32838546.67 |
-| go                        | iris                      | 96267.00 | 15078.00 | 174130.00 | 35769067.00 |
-| go                        | fasthttprouter            | 160652.33 | 6156.33 | 53915.67 | 73558143.33 |
-| go                        | gin                       | 36927.67 | 31137.33 | 148275.67 | 20709597.00 |
-| rust                      | actix-web                 | 188240.67 | 4367.33 | 15139.00 | 70870040.67 |
-| rust                      | iron                      | 95394.33 | 321.67 | 1094.67 | 35548869.33 |
-| rust                      | nickel                    | 104670.00 | 42.33 | 50.33 | 68611160.00 |
-| rust                      | rocket                    | 107608.67 | 68.33 | 159.00 | 49859189.33 |
-| node                      | express                   | 47823.00 | 37230.33 | 730944.33 | 39938433.00 |
-| node                      | fastify                   | 66100.67 | 27589.33 | 534516.33 | 66311172.00 |
-| node                      | polka                     | 77566.33 | 17744.67 | 232930.33 | 38042086.33 |
-| node                      | rayo                      | 76513.67 | 18590.00 | 263289.00 | 37589230.67 |
-| elixir                    | plug                      | 43648.67 | 33837.00 | 243430.67 | 29272801.00 |
-| elixir                    | phoenix                   | 38188.33 | 36290.33 | 232460.67 | 25718128.33 |
-| swift                     | vapor                     | 46053.33 | 51436.67 | 1166803.00 | 16522653.33 |
-| swift                     | perfect                   | 65855.67 | 14834.67 | 17608.67 | 16999461.00 |
-| swift                     | kitura                    | 42926.00 | 22127.67 | 37097.67 | 26409534.00 |
-| scala                     | akkahttp                  | 69245.00 | 230129.33 | 5289308.67 | 53127119.00 |
-| csharp                    | aspnetcore                | 117176.00 | 8602.67 | 17974.67 | 61599543.33 |
-| python                    | sanic                     | 48795.00 | 19507.00 | 36879.67 | 29155520.67 |
-| python                    | japronto                  | 86765.67 | 11057.00 | 11265.33 | 35608694.33 |
-| python                    | flask                     | 18775.00 | 50920.33 | 101835.33 | 15377015.33 |
-| python                    | django                    | 11025.67 | 89173.00 | 263761.00 | 10375313.67 |
-| python                    | tornado                   | 1910.67 | 490938.33 | 2724463.00 | 1349414.67 |
-| nim                       | jester                    | 28754.33 | 66472.00 | 1262444.67 | 10469903.00 |
-| nim                       | mofuw                     | 131842.67 | 8788.33 | 51147.67 | 80210274.67 |
-| java                      | act                       | 138188.00 | 8296.67 | 53235.33 | 73474924.33 |
-| cpp                       | evhtp                     | 158545.00 | 5397.67 | 13185.67 | 50781478.33 |
+|---------------------------|---------------------------|----------------:|----------------:|----------------:|-----------:|
+| ruby                      | rails                     | 4867.00 | 26323.33 | 162669.00 | 4.48 MB |
+| ruby                      | sinatra                   | 16715.00 | 7633.67 | 36309.33 | 14.19 MB |
+| ruby                      | roda                      | 49740.67 | 2526.00 | 11710.33 | 15.90 MB |
+| ruby                      | rack-routing              | 34272.00 | 3728.33 | 23486.00 | 6.39 MB |
+| ruby                      | flame                     | 20926.33 | 6095.33 | 27686.00 | 4.02 MB |
+| crystal                   | kemal                     | 27425.00 | 36444.00 | 57842.33 | 14.02 MB |
+| crystal                   | router.cr                 | 36517.67 | 28225.33 | 82786.00 | 10.72 MB |
+| crystal                   | raze                      | 32326.33 | 30781.33 | 48521.00 | 9.09 MB |
+| crystal                   | lucky                     | 27515.00 | 36204.33 | 56917.33 | 9.98 MB |
+| crystal                   | amber                     | 24926.33 | 40997.67 | 57698.00 | 10.52 MB |
+| crystal                   | spider-gazelle            | 30584.00 | 36200.00 | 173178.00 | 8.38 MB |
+| go                        | echo                      | 96220.67 | 10498.33 | 31915.00 | 55.34 MB |
+| go                        | gorilla-mux               | 92431.33 | 11152.33 | 36022.33 | 34.73 MB |
+| go                        | iris                      | 104717.67 | 9712.33 | 28285.00 | 39.37 MB |
+| go                        | fasthttprouter            | 168926.67 | 5657.00 | 16365.33 | 78.00 MB |
+| go                        | gin                       | 29324.67 | 52773.00 | 225567.67 | 16.74 MB |
+| rust                      | actix-web                 | 193921.33 | 4728.33 | 14374.67 | 72.90 MB |
+| rust                      | iron                      | 90255.00 | 663.00 | 3873.00 | 30.55 MB |
+| rust                      | nickel                    | 69629.33 | 123.33 | 652.00 | 47.40 MB |
+| rust                      | rocket                    | 81630.00 | 172.00 | 1159.00 | 33.37 MB |
+| node                      | express                   | 44856.67 | 34392.67 | 524501.67 | 37.87 MB |
+| node                      | fastify                   | 61676.67 | 26339.33 | 431968.67 | 61.60 MB |
+| node                      | polka                     | 77936.67 | 19126.67 | 291491.00 | 40.83 MB |
+| elixir                    | plug                      | 48104.67 | 25085.33 | 161449.33 | 31.40 MB |
+| elixir                    | phoenix                   | 32512.00 | 42085.00 | 522119.67 | 22.71 MB |
+| swift                     | vapor                     | 48879.33 | 28451.33 | 405902.67 | 17.59 MB |
+| swift                     | perfect                   | 51061.33 | 19425.67 | 24855.00 | 14.39 MB |
+| swift                     | kitura                    | 31047.33 | 31437.67 | 43421.00 | 17.40 MB |
+| scala                     | akkahttp                  | 35226.00 | 214843.67 | 4444267.33 | 31.40 MB |
+| csharp                    | aspnetcore                | 79716.67 | 13068.00 | 45945.00 | 42.23 MB |
+| python                    | sanic                     | 38882.33 | 26593.33 | 82150.67 | 24.53 MB |
+| python                    | japronto                  | 45671.33 | 21940.00 | 28894.33 | 18.32 MB |
+| python                    | flask                     | 15657.67 | 65211.00 | 204498.33 | 13.06 MB |
+| python                    | django                    | 9283.67 | 107230.33 | 273896.67 | 8.92 MB |
+| python                    | tornado                   | 1201.00 | 781124.67 | 4114950.33 | 0.86 MB |
+| nim                       | jester                    | 15816.33 | 227326.67 | 4441944.33 | 5.86 MB |
+| nim                       | mofuw                     | 112033.33 | 16236.33 | 149419.67 | 66.88 MB |
+| java                      | act                       | 105662.00 | 11537.67 | 61959.00 | 37.24 MB |
+| cpp                       | evhtp                     | 152686.67 | 6143.33 | 18806.00 | 51.09 MB |
 <!-- Result till here -->
 
 ## The rule

--- a/README.md
+++ b/README.md
@@ -16,105 +16,105 @@ CPU Cores: 8
 
 ### Ranking (Framework)
 
-1. [tornado](https://github.com/tornadoweb/tornado) (python)
-2. [akkahttp](https://github.com/akka/akka-http) (scala)
-3. [rails](https://github.com/rails/rails) (ruby)
-4. [django](https://github.com/django/django) (python)
-5. [sinatra](https://github.com/sinatra/sinatra) (ruby)
-6. [flask](https://github.com/pallets/flask) (python)
-7. [flame](https://github.com/AlexWayfer/flame) (ruby)
-8. [express](https://github.com/expressjs/express) (node)
-9. [jester](https://github.com/dom96/jester) (nim)
-10. [act](https://github.com/actframework/actframework) (java)
-11. [sanic](https://github.com/channelcat/sanic) (python)
-12. [amber](https://github.com/amberframework/amber) (crystal)
-13. [fastify](https://github.com/fastify/fastify) (node)
-14. [gin](https://github.com/gin-gonic/gin) (go)
-15. [kemal](https://github.com/kemalcr/kemal) (crystal)
-16. [lucky](https://github.com/luckyframework/lucky) (crystal)
-17. [polka](https://github.com/lukeed/polka) (node)
-18. [spider-gazelle](https://github.com/spider-gazelle/spider-gazelle) (crystal)
-19. [raze](https://github.com/samueleaton/raze) (crystal)
-20. [rack-routing](https://github.com/iAmPlus/rack-routing) (ruby)
-21. [router.cr](https://github.com/tbrand/router.cr) (crystal)
-22. [kitura](https://github.com/IBM-Swift/Kitura) (swift)
-23. [aspnetcore](https://github.com/aspnet/Home) (csharp)
-24. [phoenix](https://github.com/phoenixframework/phoenix) (elixir)
-25. [roda](https://github.com/jeremyevans/roda) (ruby)
-26. [vapor](https://github.com/vapor/vapor) (swift)
-27. [plug](https://github.com/elixir-lang/plug) (elixir)
-28. [rocket](https://github.com/SergioBenitez/Rocket) (rust)
-29. [nickel](https://github.com/nickel-org/nickel.rs) (rust)
-30. [iron](https://github.com/iron/iron) (rust)
-31. [echo](https://github.com/labstack/echo) (go)
-32. [gorilla-mux](https://github.com/gorilla/mux) (go)
-33. [iris](https://github.com/kataras/iris) (go)
-34. [mofuw](https://github.com/2vg/mofuw) (nim)
-35. [perfect](https://github.com/PerfectlySoft/Perfect) (swift)
-36. [actix-web](https://github.com/actix/actix-web) (rust)
-37. [japronto](https://github.com/squeaky-pl/japronto) (python)
-38. [evhtp](https://github.com/criticalstack/libevhtp) (cpp)
-39. [fasthttprouter](https://github.com/buaazp/fasthttprouter) (go)
+1. [evhtp](https://github.com/criticalstack/libevhtp) (cpp)
+2. [actix-web](https://github.com/actix/actix-web) (rust)
+3. [fasthttprouter](https://github.com/buaazp/fasthttprouter) (go)
+4. [mofuw](https://github.com/2vg/mofuw) (nim)
+5. [iron](https://github.com/iron/iron) (rust)
+6. [gorilla-mux](https://github.com/gorilla/mux) (go)
+7. [aspnetcore](https://github.com/aspnet/Home) (csharp)
+8. [echo](https://github.com/labstack/echo) (go)
+9. [rocket](https://github.com/SergioBenitez/Rocket) (rust)
+10. [iris](https://github.com/kataras/iris) (go)
+11. [act](https://github.com/actframework/actframework) (java)
+12. [polka](https://github.com/lukeed/polka) (node)
+13. [nickel](https://github.com/nickel-org/nickel.rs) (rust)
+14. [perfect](https://github.com/PerfectlySoft/Perfect) (swift)
+15. [japronto](https://github.com/squeaky-pl/japronto) (python)
+16. [vapor](https://github.com/vapor/vapor) (swift)
+17. [fastify](https://github.com/fastify/fastify) (node)
+18. [roda](https://github.com/jeremyevans/roda) (ruby)
+19. [sanic](https://github.com/channelcat/sanic) (python)
+20. [plug](https://github.com/elixir-lang/plug) (elixir)
+21. [phoenix](https://github.com/phoenixframework/phoenix) (elixir)
+22. [rack-routing](https://github.com/iAmPlus/rack-routing) (ruby)
+23. [spider-gazelle](https://github.com/spider-gazelle/spider-gazelle) (crystal)
+24. [kitura](https://github.com/IBM-Swift/Kitura) (swift)
+25. [router.cr](https://github.com/tbrand/router.cr) (crystal)
+26. [raze](https://github.com/samueleaton/raze) (crystal)
+27. [kemal](https://github.com/kemalcr/kemal) (crystal)
+28. [amber](https://github.com/amberframework/amber) (crystal)
+29. [lucky](https://github.com/luckyframework/lucky) (crystal)
+30. [gin](https://github.com/gin-gonic/gin) (go)
+31. [express](https://github.com/expressjs/express) (node)
+32. [flame](https://github.com/AlexWayfer/flame) (ruby)
+33. [flask](https://github.com/pallets/flask) (python)
+34. [jester](https://github.com/dom96/jester) (nim)
+35. [sinatra](https://github.com/sinatra/sinatra) (ruby)
+36. [django](https://github.com/django/django) (python)
+37. [akkahttp](https://github.com/akka/akka-http) (scala)
+38. [rails](https://github.com/rails/rails) (ruby)
+39. [tornado](https://github.com/tornadoweb/tornado) (python)
 
 ### Ranking (Language)
 
-1. python ([tornado](https://github.com/tornadoweb/tornado))
-2. scala ([akkahttp](https://github.com/akka/akka-http))
-3. ruby ([rails](https://github.com/rails/rails))
-4. node ([express](https://github.com/expressjs/express))
-5. nim ([jester](https://github.com/dom96/jester))
+1. cpp ([evhtp](https://github.com/criticalstack/libevhtp))
+2. rust ([actix-web](https://github.com/actix/actix-web))
+3. go ([fasthttprouter](https://github.com/buaazp/fasthttprouter))
+4. nim ([mofuw](https://github.com/2vg/mofuw))
+5. csharp ([aspnetcore](https://github.com/aspnet/Home))
 6. java ([act](https://github.com/actframework/actframework))
-7. crystal ([amber](https://github.com/amberframework/amber))
-8. go ([gin](https://github.com/gin-gonic/gin))
-9. swift ([kitura](https://github.com/IBM-Swift/Kitura))
-10. csharp ([aspnetcore](https://github.com/aspnet/Home))
-11. elixir ([phoenix](https://github.com/phoenixframework/phoenix))
-12. rust ([rocket](https://github.com/SergioBenitez/Rocket))
-13. cpp ([evhtp](https://github.com/criticalstack/libevhtp))
+7. node ([polka](https://github.com/lukeed/polka))
+8. swift ([perfect](https://github.com/PerfectlySoft/Perfect))
+9. python ([japronto](https://github.com/squeaky-pl/japronto))
+10. ruby ([roda](https://github.com/jeremyevans/roda))
+11. elixir ([plug](https://github.com/elixir-lang/plug))
+12. crystal ([spider-gazelle](https://github.com/spider-gazelle/spider-gazelle))
+13. scala ([akkahttp](https://github.com/akka/akka-http))
 
 ### All frameworks
 
 | Language (Runtime)        | Framework (Middleware)    |          Errors |    Requests / s |      Throughput |
 |---------------------------|---------------------------|-----------------|-----------------|-----------------|
-| ruby                      | rails                     |               0 |         4698.26 |        802.93KB |
-| ruby                      | sinatra                   |               0 |        15667.12 |          2.57MB |
-| ruby                      | roda                      |               0 |        54040.28 |          3.25MB |
-| ruby                      | rack-routing              |               0 |        40663.68 |          1.47MB |
-| ruby                      | flame                     |               0 |        19446.71 |        721.66KB |
-| crystal                   | kemal                     |               0 |        35102.26 |          3.62MB |
-| crystal                   | router.cr                 |               0 |        43350.97 |          2.56MB |
-| crystal                   | raze                      |               0 |        39309.05 |          2.32MB |
-| crystal                   | lucky                     |               0 |        35279.23 |          2.62MB |
-| crystal                   | amber                     |               0 |        31209.24 |          2.86MB |
-| crystal                   | spider-gazelle            |               0 |         38913.9 |          2.30MB |
-| go                        | echo                      |               0 |        63605.81 |          7.04MB |
-| go                        | gorilla-mux               |               0 |        64775.51 |          4.63MB |
-| go                        | iris                      |               0 |        65065.73 |          4.65MB |
-| go                        | fasthttprouter            |               0 |        73971.65 |          6.56MB |
-| go                        | gin                       |               0 |        33294.65 |          3.68MB |
-| rust                      | actix-web                 |               0 |         68460.3 |          4.90MB |
-| rust                      | iron                      |               0 |        62739.15 |          4.49MB |
-| rust                      | nickel                    |               0 |        62119.73 |          7.70MB |
-| rust                      | rocket                    |               0 |        58565.76 |          5.08MB |
-| node                      | express                   |               0 |        22114.64 |          3.42MB |
-| node                      | fastify                   |               0 |        31516.64 |          2.98MB |
-| node                      | polka                     |               0 |         38555.0 |          3.64MB |
-| elixir                    | plug                      |               0 |        57877.82 |          7.89MB |
-| elixir                    | phoenix                   |               0 |        52874.33 |          7.21MB |
-| swift                     | vapor                     |               0 |         57035.2 |          4.08MB |
-| swift                     | perfect                   |               0 |        68101.94 |          4.03MB |
-| swift                     | kitura                    |               0 |        45687.22 |          5.36MB |
-| scala                     | akkahttp                  |               0 |         2498.24 |        346.44KB |
-| csharp                    | aspnetcore                |               0 |        48488.55 |          4.90MB |
-| python                    | sanic                     |               0 |        28817.52 |          3.27MB |
-| python                    | japronto                  |               0 |        68802.77 |          5.18MB |
-| python                    | flask                     |               0 |        18879.86 |          2.93MB |
-| python                    | django                    |               0 |         12289.3 |          2.25MB |
-| python                    | tornado                   |               0 |         1441.31 |        273.06KB |
-| nim                       | jester                    |               0 |        22920.28 |          1.68MB |
-| nim                       | mofuw                     |               0 |        65430.19 |          7.43MB |
-| java                      | act                       |               0 |        24037.43 |          2.59MB |
-| cpp                       | evhtp                     |               0 |        70038.91 |          4.27MB |
+| ruby                      | rails                     |               0 |          5244.0 |          0.88MB |
+| ruby                      | sinatra                   |               0 |        18319.21 |          3.00MB |
+| ruby                      | roda                      |               0 |        51746.05 |          3.11MB |
+| ruby                      | rack-routing              |               0 |        38970.56 |          1.41MB |
+| ruby                      | flame                     |               0 |        20051.54 |        744.10KB |
+| crystal                   | kemal                     |               0 |        30853.43 |          3.18MB |
+| crystal                   | router.cr                 |               0 |        36430.32 |          2.15MB |
+| crystal                   | raze                      |               0 |        33763.82 |          2.00MB |
+| crystal                   | lucky                     |               0 |        29881.06 |          2.22MB |
+| crystal                   | amber                     |               0 |        30195.57 |          2.76MB |
+| crystal                   | spider-gazelle            |               0 |        37697.55 |          2.23MB |
+| go                        | echo                      |               0 |        96148.61 |         10.64MB |
+| go                        | gorilla-mux               |               0 |       104014.08 |          7.44MB |
+| go                        | iris                      |               0 |         88321.3 |          6.32MB |
+| go                        | fasthttprouter            |               0 |       155974.14 |         13.83MB |
+| go                        | gin                       |               0 |        28294.89 |          3.13MB |
+| rust                      | actix-web                 |               0 |       182784.28 |         13.07MB |
+| rust                      | iron                      |               0 |       104671.44 |          7.49MB |
+| rust                      | nickel                    |               0 |        75911.41 |          9.41MB |
+| rust                      | rocket                    |               0 |         92901.0 |          8.06MB |
+| node                      | express                   |               0 |        24262.72 |          3.75MB |
+| node                      | fastify                   |               0 |        53698.26 |          5.07MB |
+| node                      | polka                     |               0 |        76523.19 |          7.22MB |
+| elixir                    | plug                      |               0 |        47695.39 |          6.50MB |
+| elixir                    | phoenix                   |               0 |        41442.85 |          5.65MB |
+| swift                     | vapor                     |               0 |        54414.23 |          3.89MB |
+| swift                     | perfect                   |               0 |        73990.89 |          4.37MB |
+| swift                     | kitura                    |               0 |        36446.95 |          4.28MB |
+| scala                     | akkahttp                  |               0 |         9815.91 |          1.33MB |
+| csharp                    | aspnetcore                |               0 |        103493.5 |         10.46MB |
+| python                    | sanic                     |               0 |        50452.43 |          5.73MB |
+| python                    | japronto                  |               0 |        55134.46 |          4.15MB |
+| python                    | flask                     |               0 |        19839.14 |          3.08MB |
+| python                    | django                    |               0 |        12533.96 |          2.30MB |
+| python                    | tornado                   |               0 |         1309.27 |        248.04KB |
+| nim                       | jester                    |               0 |        19409.12 |          1.43MB |
+| nim                       | mofuw                     |               0 |       114043.75 |         12.94MB |
+| java                      | act                       |               0 |        77115.44 |          8.31MB |
+| cpp                       | evhtp                     |               0 |       185815.53 |         11.34MB |
 <!-- Result till here -->
 
 ## The rule

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Any idea is :heart:, let discuss about it on [![Join the chat at https://gitter.
 ## Result
 
 <!-- Result from here -->
-Last update: 2018-06-06
+Last update: 2018-06-08
 ```
 OS: Linux (version: 4.16.11-100.fc26.x86_64, arch: x86_64)
 CPU Cores: 8
@@ -16,155 +16,106 @@ CPU Cores: 8
 
 ### Ranking (Framework)
 
-1. [fasthttprouter](https://github.com/buaazp/fasthttprouter) (go)
-2. [rocket](https://github.com/SergioBenitez/Rocket) (rust)
-3. [actix-web](https://github.com/actix/actix-web) (rust)
-4. [evhtp](https://github.com/criticalstack/libevhtp) (cpp)
-5. [nickel](https://github.com/nickel-org/nickel.rs) (rust)
-6. [japronto](https://github.com/squeaky-pl/japronto) (python)
-7. [iron](https://github.com/iron/iron) (rust)
-8. [echo](https://github.com/labstack/echo) (go)
-9. [iris](https://github.com/kataras/iris) (go)
-10. [gorilla-mux](https://github.com/gorilla/mux) (go)
-11. [vapor](https://github.com/vapor/vapor) (swift)
-12. [router.cr](https://github.com/tbrand/router.cr) (crystal)
+1. [tornado](https://github.com/tornadoweb/tornado) (python)
+2. [akkahttp](https://github.com/akka/akka-http) (scala)
+3. [rails](https://github.com/rails/rails) (ruby)
+4. [django](https://github.com/django/django) (python)
+5. [sinatra](https://github.com/sinatra/sinatra) (ruby)
+6. [flask](https://github.com/pallets/flask) (python)
+7. [flame](https://github.com/AlexWayfer/flame) (ruby)
+8. [express](https://github.com/expressjs/express) (node)
+9. [jester](https://github.com/dom96/jester) (nim)
+10. [act](https://github.com/actframework/actframework) (java)
+11. [sanic](https://github.com/channelcat/sanic) (python)
+12. [amber](https://github.com/amberframework/amber) (crystal)
 13. [fastify](https://github.com/fastify/fastify) (node)
-14. [raze](https://github.com/samueleaton/raze) (crystal)
-15. [polka](https://github.com/lukeed/polka) (node)
-16. [plug](https://github.com/elixir-lang/plug) (elixir)
-17. [spider-gazelle](https://github.com/spider-gazelle/spider-gazelle) (crystal)
-18. [act](https://github.com/actframework/actframework) (java)
-19. [amber](https://github.com/amberframework/amber) (crystal)
-20. [roda](https://github.com/jeremyevans/roda) (ruby)
-21. [express](https://github.com/expressjs/express) (node)
-22. [lucky](https://github.com/luckyframework/lucky) (crystal)
-23. [kemal](https://github.com/kemalcr/kemal) (crystal)
-24. [perfect](https://github.com/PerfectlySoft/Perfect) (swift)
-25. [phoenix](https://github.com/phoenixframework/phoenix) (elixir)
-26. [kitura](https://github.com/IBM-Swift/Kitura) (swift)
-27. [aspnetcore](https://github.com/aspnet/Home) (csharp)
-28. [rack-routing](https://github.com/iAmPlus/rack-routing) (ruby)
-29. [sanic](https://github.com/channelcat/sanic) (python)
-30. [flame](https://github.com/AlexWayfer/flame) (ruby)
-31. [akkahttp](https://github.com/akka/akka-http) (scala)
-32. [flask](https://github.com/pallets/flask) (python)
-33. [sinatra](https://github.com/sinatra/sinatra) (ruby)
-34. [django](https://github.com/django/django) (python)
-35. [jester](https://github.com/dom96/jester) (nim)
-36. [mofuw](https://github.com/2vg/mofuw) (nim)
-37. [rails](https://github.com/rails/rails) (ruby)
-38. [tornado](https://github.com/tornadoweb/tornado) (python)
-39. [gin](https://github.com/gin-gonic/gin) (go)
+14. [gin](https://github.com/gin-gonic/gin) (go)
+15. [kemal](https://github.com/kemalcr/kemal) (crystal)
+16. [lucky](https://github.com/luckyframework/lucky) (crystal)
+17. [polka](https://github.com/lukeed/polka) (node)
+18. [spider-gazelle](https://github.com/spider-gazelle/spider-gazelle) (crystal)
+19. [raze](https://github.com/samueleaton/raze) (crystal)
+20. [rack-routing](https://github.com/iAmPlus/rack-routing) (ruby)
+21. [router.cr](https://github.com/tbrand/router.cr) (crystal)
+22. [kitura](https://github.com/IBM-Swift/Kitura) (swift)
+23. [aspnetcore](https://github.com/aspnet/Home) (csharp)
+24. [phoenix](https://github.com/phoenixframework/phoenix) (elixir)
+25. [roda](https://github.com/jeremyevans/roda) (ruby)
+26. [vapor](https://github.com/vapor/vapor) (swift)
+27. [plug](https://github.com/elixir-lang/plug) (elixir)
+28. [rocket](https://github.com/SergioBenitez/Rocket) (rust)
+29. [nickel](https://github.com/nickel-org/nickel.rs) (rust)
+30. [iron](https://github.com/iron/iron) (rust)
+31. [echo](https://github.com/labstack/echo) (go)
+32. [gorilla-mux](https://github.com/gorilla/mux) (go)
+33. [iris](https://github.com/kataras/iris) (go)
+34. [mofuw](https://github.com/2vg/mofuw) (nim)
+35. [perfect](https://github.com/PerfectlySoft/Perfect) (swift)
+36. [actix-web](https://github.com/actix/actix-web) (rust)
+37. [japronto](https://github.com/squeaky-pl/japronto) (python)
+38. [evhtp](https://github.com/criticalstack/libevhtp) (cpp)
+39. [fasthttprouter](https://github.com/buaazp/fasthttprouter) (go)
 
 ### Ranking (Language)
 
-1. go ([fasthttprouter](https://github.com/buaazp/fasthttprouter))
-2. rust ([rocket](https://github.com/SergioBenitez/Rocket))
-3. cpp ([evhtp](https://github.com/criticalstack/libevhtp))
-4. python ([japronto](https://github.com/squeaky-pl/japronto))
-5. swift ([vapor](https://github.com/vapor/vapor))
-6. crystal ([router.cr](https://github.com/tbrand/router.cr))
-7. node ([fastify](https://github.com/fastify/fastify))
-8. elixir ([plug](https://github.com/elixir-lang/plug))
-9. java ([act](https://github.com/actframework/actframework))
-10. ruby ([roda](https://github.com/jeremyevans/roda))
-11. csharp ([aspnetcore](https://github.com/aspnet/Home))
-12. scala ([akkahttp](https://github.com/akka/akka-http))
-13. nim ([jester](https://github.com/dom96/jester))
+1. python ([tornado](https://github.com/tornadoweb/tornado))
+2. scala ([akkahttp](https://github.com/akka/akka-http))
+3. ruby ([rails](https://github.com/rails/rails))
+4. node ([express](https://github.com/expressjs/express))
+5. nim ([jester](https://github.com/dom96/jester))
+6. java ([act](https://github.com/actframework/actframework))
+7. crystal ([amber](https://github.com/amberframework/amber))
+8. go ([gin](https://github.com/gin-gonic/gin))
+9. swift ([kitura](https://github.com/IBM-Swift/Kitura))
+10. csharp ([aspnetcore](https://github.com/aspnet/Home))
+11. elixir ([phoenix](https://github.com/phoenixframework/phoenix))
+12. rust ([rocket](https://github.com/SergioBenitez/Rocket))
+13. cpp ([evhtp](https://github.com/criticalstack/libevhtp))
 
 ### All frameworks
 
-| Language (Runtime)        | Framework (Middleware)    |         Minimum |         Maximum |         Average |
+| Language (Runtime)        | Framework (Middleware)    |          Errors |    Requests / s |      Throughput |
 |---------------------------|---------------------------|-----------------|-----------------|-----------------|
-| ruby                      | rails                     |             674 |           60534 |            2405 |
-| ruby                      | sinatra                   |             204 |           27742 |             819 |
-| ruby                      | roda                      |              73 |           18256 |             282 |
-| ruby                      | rack-routing              |              90 |           21269 |             340 |
-| ruby                      | flame                     |             141 |           42077 |             647 |
-| crystal                   | kemal                     |              29 |            5698 |             285 |
-| crystal                   | router.cr                 |              27 |            8791 |             246 |
-| crystal                   | raze                      |              27 |            9522 |             257 |
-| crystal                   | lucky                     |              28 |            7530 |             285 |
-| crystal                   | amber                     |              28 |            6487 |             276 |
-| crystal                   | spider-gazelle            |              26 |            8943 |             269 |
-| go                        | echo                      |              35 |           15384 |             190 |
-| go                        | gorilla-mux               |              33 |           19486 |             222 |
-| go                        | iris                      |              33 |           20959 |             204 |
-| go                        | fasthttprouter            |              23 |           15676 |             120 |
-| go                        | gin                       |              46 |          251860 |            8248 |
-| rust                      | actix-web                 |              26 |           16757 |             163 |
-| rust                      | iron                      |              43 |           15754 |             176 |
-| rust                      | nickel                    |              35 |           16226 |             173 |
-| rust                      | rocket                    |              37 |           16426 |             141 |
-| node                      | express                   |              52 |           29245 |             284 |
-| node                      | fastify                   |              35 |           23115 |             250 |
-| node                      | polka                     |              33 |           30454 |             260 |
-| elixir                    | plug                      |              52 |           10370 |             263 |
-| elixir                    | phoenix                   |              62 |           16288 |             297 |
-| swift                     | vapor                     |              64 |           23145 |             244 |
-| swift                     | perfect                   |              36 |           21161 |             287 |
-| swift                     | kitura                    |              92 |           15020 |             312 |
-| scala                     | akkahttp                  |              51 |          365932 |             652 |
-| csharp                    | aspnetcore                |              47 |          241092 |             317 |
-| python                    | sanic                     |             120 |           17025 |             363 |
-| python                    | japronto                  |              26 |            7221 |             175 |
-| python                    | flask                     |             262 |           18447 |             763 |
-| python                    | django                    |             392 |           29087 |            1124 |
-| python                    | tornado                   |            1100 |           21074 |            6916 |
-| nim                       | jester                    |              56 |           32982 |            1239 |
-| nim                       | mofuw                     |              31 |           88467 |            2339 |
-| java                      | act                       |              28 |          129573 |             275 |
-| cpp                       | evhtp                     |              28 |           16019 |             165 |
+| ruby                      | rails                     |               0 |         4698.26 |        802.93KB |
+| ruby                      | sinatra                   |               0 |        15667.12 |          2.57MB |
+| ruby                      | roda                      |               0 |        54040.28 |          3.25MB |
+| ruby                      | rack-routing              |               0 |        40663.68 |          1.47MB |
+| ruby                      | flame                     |               0 |        19446.71 |        721.66KB |
+| crystal                   | kemal                     |               0 |        35102.26 |          3.62MB |
+| crystal                   | router.cr                 |               0 |        43350.97 |          2.56MB |
+| crystal                   | raze                      |               0 |        39309.05 |          2.32MB |
+| crystal                   | lucky                     |               0 |        35279.23 |          2.62MB |
+| crystal                   | amber                     |               0 |        31209.24 |          2.86MB |
+| crystal                   | spider-gazelle            |               0 |         38913.9 |          2.30MB |
+| go                        | echo                      |               0 |        63605.81 |          7.04MB |
+| go                        | gorilla-mux               |               0 |        64775.51 |          4.63MB |
+| go                        | iris                      |               0 |        65065.73 |          4.65MB |
+| go                        | fasthttprouter            |               0 |        73971.65 |          6.56MB |
+| go                        | gin                       |               0 |        33294.65 |          3.68MB |
+| rust                      | actix-web                 |               0 |         68460.3 |          4.90MB |
+| rust                      | iron                      |               0 |        62739.15 |          4.49MB |
+| rust                      | nickel                    |               0 |        62119.73 |          7.70MB |
+| rust                      | rocket                    |               0 |        58565.76 |          5.08MB |
+| node                      | express                   |               0 |        22114.64 |          3.42MB |
+| node                      | fastify                   |               0 |        31516.64 |          2.98MB |
+| node                      | polka                     |               0 |         38555.0 |          3.64MB |
+| elixir                    | plug                      |               0 |        57877.82 |          7.89MB |
+| elixir                    | phoenix                   |               0 |        52874.33 |          7.21MB |
+| swift                     | vapor                     |               0 |         57035.2 |          4.08MB |
+| swift                     | perfect                   |               0 |        68101.94 |          4.03MB |
+| swift                     | kitura                    |               0 |        45687.22 |          5.36MB |
+| scala                     | akkahttp                  |               0 |         2498.24 |        346.44KB |
+| csharp                    | aspnetcore                |               0 |        48488.55 |          4.90MB |
+| python                    | sanic                     |               0 |        28817.52 |          3.27MB |
+| python                    | japronto                  |               0 |        68802.77 |          5.18MB |
+| python                    | flask                     |               0 |        18879.86 |          2.93MB |
+| python                    | django                    |               0 |         12289.3 |          2.25MB |
+| python                    | tornado                   |               0 |         1441.31 |        273.06KB |
+| nim                       | jester                    |               0 |        22920.28 |          1.68MB |
+| nim                       | mofuw                     |               0 |        65430.19 |          7.43MB |
+| java                      | act                       |               0 |        24037.43 |          2.59MB |
+| cpp                       | evhtp                     |               0 |        70038.91 |          4.27MB |
 <!-- Result till here -->
-
-## Current target frameworks (middlewares)
-
- - Ruby
-   - [Rails](https://github.com/rails/rails)
-   - [Sinatra](https://github.com/sinatra/sinatra)
-   - [Roda](https://github.com/jeremyevans/roda)
-   - [Rack-Routing](https://github.com/georgeu2000/rack-routing)
-   - [Flame](https://github.com/AlexWayfer/flame)
- - Crystal
-   - [Kemal](https://github.com/kemalcr/kemal)
-   - [raze](https://github.com/samueleaton/raze)
-   - [router.cr](https://github.com/tbrand/router.cr)
- - Go
-   - [Echo](https://github.com/labstack/echo)
-   - [gorilla-mux](https://github.com/gorilla/mux)
-   - [iris](https://github.com/kataras/iris)
-   - [fasthttprouter](https://github.com/buaazp/fasthttprouter)
-   - [Gin](https://github.com/gin-gonic/gin)
- - Rust
-   - [IRON](https://github.com/iron/iron)
-   - [nickel.rs](https://github.com/nickel-org/nickel.rs)
-   - [Rocket](https://rocket.rs) (nightly)
- - node
-   - [express](https://github.com/expressjs/express)
-   - [polka](https://github.com/lukeed/polka)
- - Elixir
-   - [Plug](http://github.com/elixir-lang/plug)
-   - [Phoenix](http://github.com/phoenixframework/phoenix)
- - Swift
-   - [Vapor](https://vapor.codes)
-   - [Perfect](https://www.perfect.org)
-   - [Kitura](http://www.kitura.io)
- - Scala
-   - [Akka-Http (Routing DSL)](http://doc.akka.io/docs/akka-http/current/scala/http/introduction.html#routing-dsl-for-http-servers)
- - C#
-   - [ASP.NET Core](https://www.microsoft.com/net/core)
- - Python
-   - [sanic](https://github.com/channelcat/sanic)
-   - [japronto](https://github.com/squeaky-pl/japronto)
-   - [flask](https://github.com/pallets/flask)
-   - [tornado](https://github.com/tornadoweb/tornado)
- - Nim
-   - [Jester](https://github.com/dom96/jester)
-   - [mofuw](https://github.com/2vg/mofuw)
- - Objective-C
-   - [Criollo](https://criollo.io/)
-
-See Development section when you want to add new languages or frameworks.
 
 ## The rule
 

--- a/cpp/evhtp/Dockerfile
+++ b/cpp/evhtp/Dockerfile
@@ -1,7 +1,4 @@
-FROM gcc
-
-RUN apt-get -qq update
-RUN apt-get -qy install cmake
+FROM rikorose/gcc-cmake
 
 WORKDIR /usr/src/app
 COPY . .

--- a/neph.yaml
+++ b/neph.yaml
@@ -12,6 +12,7 @@ main:
     - cpp
     - scala
     - csharp
+    - java
 
 crystal:
   depends_on:
@@ -86,6 +87,10 @@ scala:
 csharp:
   depends_on:
     - aspnetcore
+
+java:
+  depends_on:
+    - act
 
 router.cr:
   command: docker build -t router.cr .
@@ -238,3 +243,7 @@ akkahttp:
 aspnetcore:
   command: docker build -t aspnetcore .
   dir: csharp/aspnetcore
+
+act:
+  command: docker build -t act .
+  dir: java/act

--- a/tools/pipeline.lua
+++ b/tools/pipeline.lua
@@ -1,5 +1,12 @@
+-- Inspired by https://github.com/TechEmpower/FrameworkBenchmarks/issues/2960
+
 done = function(summary, latency, requests)
+  avg = latency.mean
+  max = latency.max
+  min = latency.min
+  req = summary.requests
+  time = summary.duration
   file = io.open('/tmp/which_is_the_fastest.out', 'w')
-  file:write(string.format("%d,%d,%d\n", latency.min, latency.max, latency.mean))
+  file:write(string.format("%d,%d,%d,%d,%d\n", time, avg, max, min, req))
   file.close(file)
 end

--- a/tools/pipeline.lua
+++ b/tools/pipeline.lua
@@ -1,12 +1,5 @@
--- Inspired by https://github.com/TechEmpower/FrameworkBenchmarks/issues/2960
-
 done = function(summary, latency, requests)
-  avg = latency.mean
-  max = latency.max
-  min = latency.min
-  req = summary.requests
-  time = summary.duration
   file = io.open('/tmp/which_is_the_fastest.out', 'w')
-  file:write(string.format("%d,%d,%d,%d,%d\n", time, avg, max, min, req))
+  file:write(string.format("%d\n", summary.errors.connect))
   file.close(file)
 end

--- a/tools/pipeline.lua
+++ b/tools/pipeline.lua
@@ -1,5 +1,50 @@
+-- duration in microseconds
+-- total completed requests
+-- total completed requests per seconds
+-- total bytes received
+-- total socket connection errors
+-- total socket read errors
+-- total socket write errors
+-- total http errors (status > 399)
+-- total request timeouts
+-- minimim latency
+-- maximum latency
+-- average latency
+-- standard deviation
+-- percentile : 50
+-- percentile : 90
+-- percentile : 99
+-- percentile : 99.999
+  
 done = function(summary, latency, requests)
   file = io.open('/tmp/which_is_the_fastest.out', 'w')
-  file:write(string.format("%d\n", summary.errors.connect))
+
+  out = {
+    summary.duration,
+    summary.requests,
+    summary.requests/(summary.duration/1000000),
+    summary.bytes,
+    summary.errors.connect,
+    summary.errors.read,
+    summary.errors.write,
+    summary.errors.status,
+    summary.errors.timeout,
+    latency.min,
+    latency.max,
+    latency.mean,
+    latency.stdev,
+    latency:percentile(50),
+    latency:percentile(90),
+    latency:percentile(99),
+    latency:percentile(99.999)
+  }
+
+  for key, value in pairs(out) do
+    if key > 1 then
+      file:write(",")
+    end
+    file:write(string.format("%d", value))
+  end
+
   file.close(file)
 end

--- a/tools/pipeline.lua
+++ b/tools/pipeline.lua
@@ -1,0 +1,5 @@
+done = function(summary, latency, requests)
+  file = io.open('/tmp/which_is_the_fastest.out', 'w')
+  file:write(string.format("%d,%d,%d\n", latency.min, latency.max, latency.mean))
+  file.close(file)
+end

--- a/tools/pipeline_post.lua
+++ b/tools/pipeline_post.lua
@@ -1,0 +1,54 @@
+wrk.method = "POST"
+wrk.body = ""
+wrk.headers["Content-Type"] = "application/x-www-form-urlencoded"
+
+-- duration in microseconds
+-- total completed requests
+-- total completed requests per seconds
+-- total bytes received
+-- total socket connection errors
+-- total socket read errors
+-- total socket write errors
+-- total http errors (status > 399)
+-- total request timeouts
+-- minimim latency
+-- maximum latency
+-- average latency
+-- standard deviation
+-- percentile : 50
+-- percentile : 90
+-- percentile : 99
+-- percentile : 99.999
+  
+done = function(summary, latency, requests)
+  file = io.open('/tmp/which_is_the_fastest.out', 'w')
+
+  out = {
+    summary.duration,
+    summary.requests,
+    summary.requests/(summary.duration/1000000),
+    summary.bytes,
+    summary.errors.connect,
+    summary.errors.read,
+    summary.errors.write,
+    summary.errors.status,
+    summary.errors.timeout,
+    latency.min,
+    latency.max,
+    latency.mean,
+    latency.stdev,
+    latency:percentile(50),
+    latency:percentile(90),
+    latency:percentile(99),
+    latency:percentile(99.999)
+  }
+
+  for key, value in pairs(out) do
+    if key > 1 then
+      file:write(",")
+    end
+    file:write(string.format("%d", value))
+  end
+
+  file.close(file)
+end

--- a/tools/src/benchmarker.cr
+++ b/tools/src/benchmarker.cr
@@ -134,9 +134,14 @@ def benchmark(host, threads, connections) : BenchResult
 
   `#{CLIENT} -h #{host} -t #{threads.to_i} -r #{connections.to_i}`
 
-  row = File.read("/tmp/which_is_the_fastest.out").split(',')
+  row = File.read("/tmp/which_is_the_fastest.out").split(",")
+  duration = row[0].to_i
+  average = row[1].to_i
+  maximum = row[2].to_i
+  minimum = row[3].to_i
+  requests = row[4].to_i
 
-  result = BenchResult.new(row[0].to_i, row[1].to_i, row[2].to_i)
+  result = BenchResult.new(minimum, maximum, average)
 
   sleep 5
 
@@ -225,11 +230,11 @@ end
 puts_markdown "", m_lines, true
 puts_markdown "### All frameworks", m_lines, true
 puts_markdown "", m_lines, true
-puts_markdown "| %-25s | %-25s | %15s | %15s | %15s |" % ["Language (Runtime)", "Framework (Middleware)", "Minimum", "Maximu", "Average"], m_lines, true
+puts_markdown "| %-25s | %-25s | %15s | %15s | %15s |" % ["Language (Runtime)", "Framework (Middleware)", "Minimum", "Maximum", "Average"], m_lines, true
 puts_markdown "|---------------------------|---------------------------|-----------------|-----------------|-----------------|", m_lines, true
 
 all.each do |framework|
-  puts_markdown "| %-25s | %-25s | %15d | %15d | %15d" % [framework.target.lang, framework.target.name, framework.res.min, framework.res.max, framework.res.ave], m_lines, true
+  puts_markdown "| %-25s | %-25s | %15d | %15d | %15d |" % [framework.target.lang, framework.target.name, framework.res.min, framework.res.max, framework.res.ave], m_lines, true
 end
 
 if record

--- a/tools/src/benchmarker.cr
+++ b/tools/src/benchmarker.cr
@@ -305,10 +305,10 @@ unless check
   puts_markdown "", m_lines, true
 
   puts_markdown "| %-25s | %-25s | %15s | %15s | %15s | %15s |" % ["Language (Runtime)", "Framework (Middleware)", "Requests / s", "Latency", "99 percentile", "Throughput"], m_lines, true
-  puts_markdown "|---------------------------|---------------------------|----------------:|:----------------:|----------------:|-----------:|", m_lines, true
+  puts_markdown "|---------------------------|---------------------------|----------------:|----------------:|----------------:|-----------:|", m_lines, true
 
   all.each do |framework|
-    puts_markdown "| %-25s | %-25s | %.2f | %.2f | %.2f | %.2f |" % [framework.target.lang, framework.target.name, framework.res.request, framework.res.latency, framework.res.percentile, framework.res.throughput], m_lines, true
+    puts_markdown "| %-25s | %-25s | %.2f | %.2f | %.2f | %.2f MB |" % [framework.target.lang, framework.target.name, framework.res.request, framework.res.latency, framework.res.percentile, (framework.res.throughput/1000000)], m_lines, true
   end
 
   if record

--- a/tools/src/benchmarker.cr
+++ b/tools/src/benchmarker.cr
@@ -4,7 +4,7 @@ require "option_parser"
 require "json"
 
 ####################
-## DEFAULT VALUES ##
+# # DEFAULT VALUES ##
 ####################
 
 threads = (System.cpu_count + 1).to_i
@@ -13,7 +13,7 @@ record = false
 check = false
 
 #################
-#### OPTIONS ####
+# ### OPTIONS ####
 #################
 
 OptionParser.parse! do |parser|
@@ -33,7 +33,7 @@ OptionParser.parse! do |parser|
 end
 
 ################
-## FRAMEWORKS ##
+# # FRAMEWORKS ##
 ################
 
 # Prefix of pathes for each executable
@@ -108,7 +108,7 @@ LANGS = [
   ]},
   {lang: "cpp", targets: [
     {name: "evhtp", repo: "criticalstack/libevhtp"},
-  ]}
+  ]},
 ]
 
 # struct for target
@@ -141,9 +141,9 @@ end
 class Latency
   JSON.mapping(
     average: String,
-      stdev: String,
-      max: String,
-      pmstdev: String,
+    stdev: String,
+    max: String,
+    pmstdev: String,
   )
 end
 
@@ -180,7 +180,6 @@ end
 # threads : number of thread to launch simultaneously
 # connections : number of opened connections per thread
 def benchmark(host, threads, connections) : Result
-
   errors = 0
   requests = 0
   throughput = 0
@@ -221,7 +220,7 @@ ranks = [] of Ranked
 targets.each do |target|
   cid = `docker run -td #{target.name}`.strip
 
-  sleep 10 # due to external program usage
+  sleep 20 # due to external program usage
 
   remote_ip = `docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' #{cid}`.strip
 
@@ -239,9 +238,8 @@ targets.each do |target|
       STDERR.puts "Fail to POST on /user for #{target} : [#{r.status_code}] #{r.body}"
     end
   else
-  
     result = benchmark(remote_ip, threads, requests)
-  
+
     all.push(Ranked.new(result, target))
   end
 
@@ -252,50 +250,50 @@ end
 
 unless check
   ranks = all.sort do |rank0, rank1|
-    rank0.res.request.per_second <=> rank1.res.request.per_second
+    rank1.res.request.per_second <=> rank0.res.request.per_second
   end
-  
+
   # --- Ranking of frameworks
-  
+
   puts_markdown "", m_lines, true
   puts_markdown "### Ranking (Framework)", m_lines, true
   puts_markdown "", m_lines, true
-  
+
   rank = 1
-  
+
   ranks.each do |ranked|
     puts_markdown "#{rank}. [#{ranked.target.name}](https://github.com/#{ranked.target.repo}) (#{ranked.target.lang})", m_lines, true
     rank += 1
   end
-  
+
   # --- Ranking of langages
-  
+
   puts_markdown "", m_lines, true
   puts_markdown "### Ranking (Language)", m_lines, true
   puts_markdown "", m_lines, true
-  
+
   ranked_langs = [] of String
   rank = 1
-  
+
   ranks.each do |ranked|
     next if ranked_langs.includes?(ranked.target.lang)
     puts_markdown "#{rank}. #{ranked.target.lang} ([#{ranked.target.name}](https://github.com/#{ranked.target.repo}))", m_lines, true
     ranked_langs.push(ranked.target.lang)
     rank += 1
   end
-  
+
   # --- Result of all frameworks
-  
+
   puts_markdown "", m_lines, true
   puts_markdown "### All frameworks", m_lines, true
   puts_markdown "", m_lines, true
   puts_markdown "| %-25s | %-25s | %15s | %15s | %15s |" % ["Language (Runtime)", "Framework (Middleware)", "Errors", "Requests / s", "Throughput"], m_lines, true
   puts_markdown "|---------------------------|---------------------------|-----------------|-----------------|-----------------|", m_lines, true
-  
+
   all.each do |framework|
     puts_markdown "| %-25s | %-25s | %15s | %15s | %15s |" % [framework.target.lang, framework.target.name, framework.res.errors, framework.res.request.per_second, framework.res.throughput.per_second], m_lines, true
   end
-  
+
   if record
     path = File.expand_path("../../../README.md", __FILE__)
     tag_from = "<!-- Result from here -->"
@@ -306,7 +304,7 @@ unless check
     next_readme = prev_readme.gsub(
       /\<!--\sResult\sfrom\shere\s-->[\s\S]*?<!--\sResult\still\shere\s-->/,
       m_lines.join('\n'))
-  
+
     File.write(path, next_readme)
   end
 end

--- a/tools/src/client.cr
+++ b/tools/src/client.cr
@@ -1,7 +1,8 @@
+require "json"
 require "http/client"
 require "option_parser"
 
-CLIENT = File.expand_path("../../" + "pipeline.lua", __FILE__)
+PIPELINE = File.expand_path("../../" + "pipeline.lua", __FILE__)
 
 class Client
   def initialize
@@ -22,13 +23,65 @@ class Client
         @host = host
       end
       parser.on("-p PORT", "--port=PORT", "Port to test") do |port|
-	@port = port.to_i
+	      @port = port.to_i
       end
     end
   end
 
-  def run
-    `wrk --script #{CLIENT} http://#{@host}:#{@port}/`
+  def run    
+
+    results = `wrk --threads 1 --script #{PIPELINE} --connections 100 --duration 1s --timeout 5 --latency http://#{@host}:#{@port}/`.strip.lines    
+    latency = results[3].split
+    request = results[4].split
+    summary = results[10].split
+    errors = File.read("/tmp/which_is_the_fastest.out").strip
+    File.delete("/tmp/which_is_the_fastest.out")
+    
+    data = JSON.build do |json|
+      json.object do
+	json.field "errors", errors.to_i
+        
+        json.field "latency" do
+          json.object do
+            json.field "average", latency[1]
+            json.field "stdev", latency[2]
+            json.field "max", latency[3]
+            json.field "pmstdev", latency[4]
+          end
+        end
+
+        json.field "request" do
+          json.object do
+            json.field "average", request[1]
+            json.field "stdev", request[2]
+            json.field "max", request[3]
+            json.field "pmstdev", request[4]
+	    json.field "total", summary.first.to_i
+	    json.field "per_second", results[11].split(":").last.strip.to_f64
+          end
+        end
+        
+        json.field "percentile" do
+          json.object do
+            json.field "fifty", results[6].split.last
+            json.field "seventy_five", results[7].split.last
+            json.field "ninety", results[8].split.last
+            json.field "ninety_nine", results[9].split.last
+          end
+        end
+        
+        json.field "throughput" do
+          json.object do
+            json.field "total", summary[4]
+            json.field "duration", summary[3]
+            json.field "per_second", results[12].split(":").last.strip
+          end
+        end
+        
+      end
+    end
+    
+    STDOUT.puts data
   end
 end
 

--- a/tools/src/client.cr
+++ b/tools/src/client.cr
@@ -6,41 +6,49 @@ PIPELINE = File.expand_path("../../" + "pipeline.lua", __FILE__)
 
 class Client
   def initialize
-    @threads  = 16
-    @requests = 1000
+    @threads = 16
     @host = "localhost"
     @port = 3000
+    @duration = 3
+    @connections = 1000
 
     OptionParser.parse! do |parser|
       parser.banner = "Usage: time ./bin/benchmark [options]"
       parser.on("-t THREADS", "--threads=THREADS", "# of threads") do |threads|
         @threads = threads.to_i
       end
-      parser.on("-r REQUESTS", "--requests=REQUESTS", "# of iterations of requests") do |requests|
-        @requests = requests.to_i
+      parser.on("-c CONNECTIONS", "--requests=CONNECTIONS", "# of opened connections") do |connections|
+	@connections = connections.to_i
       end
       parser.on("-h HOST", "--host=HOST", "IP / address of host to test") do |host|
         @host = host
       end
       parser.on("-p PORT", "--port=PORT", "Port to test") do |port|
-	      @port = port.to_i
+        @port = port.to_i
       end
     end
   end
 
-  def run    
-
-    results = `wrk --threads 1 --script #{PIPELINE} --connections 100 --duration 1s --timeout 5 --latency http://#{@host}:#{@port}/`.strip.lines    
+  def run
+    results = `wrk --threads #{@threads} --script #{PIPELINE} --connections #{@connections} --duration #{@duration}s --timeout 5 --latency http://#{@host}:#{@port}/`.strip.lines
+    # wrk display errors (only occurs on akkahttp)
+    if results.size > 13
+      request_line = 12
+      throughput_line = 13
+    else
+      request_line = 11
+      throughput_line = 12
+    end
     latency = results[3].split
     request = results[4].split
     summary = results[10].split
     errors = File.read("/tmp/which_is_the_fastest.out").strip
     File.delete("/tmp/which_is_the_fastest.out")
-    
+
     data = JSON.build do |json|
       json.object do
-	json.field "errors", errors.to_i
-        
+        json.field "errors", errors.to_i
+
         json.field "latency" do
           json.object do
             json.field "average", latency[1]
@@ -56,11 +64,11 @@ class Client
             json.field "stdev", request[2]
             json.field "max", request[3]
             json.field "pmstdev", request[4]
-	    json.field "total", summary.first.to_i
-	    json.field "per_second", results[11].split(":").last.strip.to_f64
+            json.field "total", summary.first.to_i
+            json.field "per_second", results[request_line].split(":").last.strip.to_f64
           end
         end
-        
+
         json.field "percentile" do
           json.object do
             json.field "fifty", results[6].split.last
@@ -69,18 +77,17 @@ class Client
             json.field "ninety_nine", results[9].split.last
           end
         end
-        
+
         json.field "throughput" do
           json.object do
             json.field "total", summary[4]
             json.field "duration", summary[3]
-            json.field "per_second", results[12].split(":").last.strip
+            json.field "per_second", results[throughput_line].split(":").last.strip
           end
         end
-        
       end
     end
-    
+
     STDOUT.puts data
   end
 end

--- a/tools/src/client.cr
+++ b/tools/src/client.cr
@@ -1,6 +1,8 @@
 require "http/client"
 require "option_parser"
 
+CLIENT = File.expand_path("../../" + "pipeline.lua", __FILE__)
+
 class Client
   def initialize
     @threads  = 16
@@ -25,33 +27,8 @@ class Client
     end
   end
 
-  macro run_spawn
-    spawn do
-      c = HTTP::Client.new @host, @port
-      @requests.times do |t|
-        r = c.get  "/"
-        abort "status code should be 200 when GET /" if r.status_code != 200
-        r = c.get  "/user/#{t}"
-        abort "status code should be 200 when GET /user/:id" if r.status_code != 200
-        abort "body should be '#{t}'" if r.body.lines.first != t.to_s
-        r = c.post "/user"
-        abort "status code should be 200 when POST /user" if r.status_code != 200
-      end
-      c.close
-      channel.send(nil)
-    end
-  end
-
   def run
-    channel = Channel(Nil).new
-
-    @threads.times do |t|
-      run_spawn
-    end
-
-    @threads.times do |t|
-      channel.receive
-    end
+    `wrk --script #{CLIENT} http://#{@host}:#{@port}/`
   end
 end
 


### PR DESCRIPTION
Hi,

This `PR` enable `wrk`. Siege process is handled by `wrk` and a **custom** `lua` script, write results in a `csv` file.

The `crystal ` part parse the `csv` and compute the rank from the average latency.

I'm not quiet sure of how to define this rank (what metric should be in).

@OvermindDL1 Any idea ?

Regards,