### PR TITLE
Fix rust version for rocket

### DIFF
--- a/rust/rocket/Dockerfile
+++ b/rust/rocket/Dockerfile
@@ -2,8 +2,7 @@ FROM rust
 
 WORKDIR /usr/src/app
 
-RUN rustup default nightly
-RUN rustup update
+RUN rustup default nightly-2018-06-05
 
 COPY Cargo.toml ./
 COPY src src


### PR DESCRIPTION
Hi @SergioBenitez,

`Rocket` fails to compile on last **nightly** (from yesterday).

I have fixed compiler version.

Regards,