### PR TITLE
Fix router.cr on latest crystal

### DIFF
--- a/crystal/router.cr/src/server.cr
+++ b/crystal/router.cr/src/server.cr
@@ -24,7 +24,8 @@ struct Server
   end
 
   def run
-    server = HTTP::Server.new("0.0.0.0", 3000, route_handler)
+    server = HTTP::Server.new(route_handler)
+    server.bind_tcp("0.0.0.0", 3000, true)
     server.listen
   end
 


### PR DESCRIPTION
Hi,

`crystal` has changed (**braking change**) on `http/server`.

This implementation follow `0.25.0` and fix #257 

Regards,