### PR TITLE
Downgrade uvloop (japronto)

### DIFF
--- a/python/japronto/requirements.txt
+++ b/python/japronto/requirements.txt
@@ -3,4 +3,4 @@ japronto==0.1.1
 packaging==17.1
 pyparsing==2.2.0
 six==1.11.0
-uvloop==0.10.1
+uvloop==0.8.1


### PR DESCRIPTION
Hi,

`japronto` fails if `uvloop` `0.10.1` is used, @see #263 

This `PR` fix it by specify `0.8.1` version

Regards,