### PR TITLE
use nightlty release to compile rocket (rust)

### DIFF
--- a/rust/rocket/Dockerfile
+++ b/rust/rocket/Dockerfile
@@ -2,7 +2,7 @@ FROM rust
 
 WORKDIR /usr/src/app
 
-RUN rustup default nightly-2018-06-18
+RUN rustup default nightly
 
 COPY Cargo.toml ./
 COPY src src


### PR DESCRIPTION
Hi,

This `PR` remove **fixed** `rust` compiler version (use `nightly`) to compile `rocket`.

Fix #279 

Regards,