### PR TITLE
Downgrade python

### DIFF
--- a/python/japronto/Dockerfile
+++ b/python/japronto/Dockerfile
@@ -1,4 +1,4 @@
-FROM python
+FROM python:3.6
 
 WORKDIR /usr/src/app
 

--- a/python/japronto/requirements.txt
+++ b/python/japronto/requirements.txt
@@ -1,6 +1,1 @@
-appdirs==1.4.3
 japronto==0.1.1
-packaging==17.1
-pyparsing==2.2.0
-six==1.11.0
-uvloop==0.8.1

--- a/python/vibora/Dockerfile
+++ b/python/vibora/Dockerfile
@@ -1,4 +1,4 @@
-FROM python
+FROM python:3.6
 
 WORKDIR /usr/src/app
 

--- a/python/vibora/requirements.txt
+++ b/python/vibora/requirements.txt
@@ -1,5 +1,1 @@
-python-dateutil==2.6.1
-pendulum==2.0.2
-ujson==1.35
-uvloop==0.10.2
 vibora==0.0.6

--- a/python/vibora/server.py
+++ b/python/vibora/server.py
@@ -1,4 +1,5 @@
 from vibora import Vibora, Response
+import multiprocessing
 
 app = Vibora()
 
@@ -16,4 +17,4 @@ async def user():
     return Response(b'', headers={'content-type': 'html'})
 
 if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0', port=3000)
+    app.run(host='0.0.0.0', port=3000, workers=multiprocessing.cpu_count(), debug=False)


### PR DESCRIPTION
Hi,

This  `PR`  downgrade **python**, `3.6` instead of `3.7`, as `uvloop` is not compatible with `3.7` (yet ?)
https://github.com/MagicStack/uvloop/issues/178

@frnkvieira As far a I understand workers (at least for app I design) **SHOULD** be 1 per core. Why  `vibora` spread on `cpu_count() + 2` by default

@see https://github.com/vibora-io/vibora/blob/master/vibora/server.py#L282

@greed2411 I can see that on the implementation, you specified headers. 
Is there any idea behind that ? (there is no header in doc examples).

Regards,



