### PR TITLE
remove version specification on elixir impl

### DIFF
--- a/elixir/phoenix/mix.exs
+++ b/elixir/phoenix/mix.exs
@@ -4,7 +4,6 @@ defmodule MyPhoenix.Mixfile do
   def project do
     [app: :my_phoenix,
      version: "0.0.1",
-     elixir: "~> 1.6.4",
      elixirc_paths: elixirc_paths(Mix.env),
      compilers: [:phoenix, :gettext] ++ Mix.compilers,
      build_embedded: Mix.env == :prod,

--- a/elixir/plug/mix.exs
+++ b/elixir/plug/mix.exs
@@ -4,7 +4,6 @@ defmodule MyPlug.Mixfile do
   def project do
     [app: :my_plug,
      version: "0.1.0",
-     elixir: "~> 1.6.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps()]


### PR DESCRIPTION
Hi,

This `PR` remove version specification in `mix.exs`.

This originally fix CI, cause on **travis** `elixir` is `1.7.1` and `1.6.4` on **docker**.

Btw, version is specified on https://github.com/TechEmpower/FrameworkBenchmarks/blob/master/frameworks/Elixir/phoenix/mix.exs

@kelvinst Is it a best-practice or absolutely a horror to do ?

Regards,

PS : I'm an _interpreted_ language guy :stuck_out_tongue_winking_eye: 